### PR TITLE
Support for SAMD boards (e.g. Arduino Zero)

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ For more details on customization see corresponding section of the [wiki](https:
 
 #### Methods
 
-* **setSplash(** _uint8_t PROGMEM_ *sprite **)**  
+* **setSplash(** _const uint8_t PROGMEM_ *sprite **)**  
   *Returns*: nothing  
   Set custom sprite displayed as the splash screen when GEM is being initialized. Should be called before `GEM::init()`. The following is the format of the sprite as described in AltSerialGraphicLCD library documentation:
   > The sprite commences with two bytes which are the width and height of the image in pixels. The pixel data is organised as rows of 8 vertical pixels per byte where the least significant bit (LSB) is the top-left pixel and the most significant bit (MSB) tends towards the bottom-left pixel. A complete row of 8 vertical pixels across the image width comprises the first row, this is then followed by the next row of 8 vertical pixels and so on. Where the image height is not an exact multiple of 8 bits then any unused bits are typically set to zero (although this does not matter).
@@ -625,8 +625,8 @@ GEMItem menuItemButton(title, buttonAction);
   Title of the menu item displayed on the screen (in this case - name of the button).
 
 * **buttonAction**  
-  *Type*: `reference to function`  
-  Reference to function that will be executed when menu item is activated. Action-specific [context](#appcontext) can be created, which can have its own enter (setup) and exit callbacks as well as loop function.
+  *Type*: `pointer to function`  
+  Pointer to function that will be executed when menu item is activated. Action-specific [context](#appcontext) can be created, which can have its own enter (setup) and exit callbacks as well as loop function.
 
 #### Constants
 

--- a/examples/Example-01_Basic/Example-01_Basic.ino
+++ b/examples/Example-01_Basic/Example-01_Basic.ino
@@ -51,7 +51,7 @@ GEMItem menuItemBool("Enable print:", enablePrint);
 
 // Create menu button that will trigger printData() function. It will print value of our number variable
 // to Serial monitor if enablePrint is true. We will write (define) this function later. However, we should
-// forward-declare it in order to pass its reference to GEMItem constructor
+// forward-declare it in order to pass to GEMItem constructor
 void printData(); // Forward declaration
 GEMItem menuItemButton("Print", printData);
 

--- a/examples/Example-02_Blink/Example-02_Blink.ino
+++ b/examples/Example-02_Blink/Example-02_Blink.ino
@@ -66,12 +66,12 @@ GEMItem menuItemLabel("Label:", label);
 
 // Create menu button that will trigger blinkDelay() function. It will blink with built-in LED with delay()
 // set to the value of interval variable. We will write (define) this function later. However, we should
-// forward-declare it in order to pass its reference to GEMItem constructor
+// forward-declare it in order to pass to GEMItem constructor
 void blinkDelay(); // Forward declaration
 GEMItem menuItemDelayButton1("Blink v1", blinkDelay);
 // Likewise, create menu button that will trigger blinkMillis() function. It will blink with built-in LED with millis based
 // delay set to the value of interval variable. We will write (define) this function later. However, we should
-// forward-declare it in order to pass its reference to GEMItem constructor
+// forward-declare it in order to pass to GEMItem constructor
 void blinkMillis(); // Forward declaration
 GEMItem menuItemDelayButton2("Blink v2", blinkMillis);
 

--- a/examples/Example-03_Party-Hard/Example-03_Party-Hard.ino
+++ b/examples/Example-03_Party-Hard/Example-03_Party-Hard.ino
@@ -79,7 +79,7 @@ GEMItem menuItemTempo("Tempo:", tempo, selectTempo, applyTempo);
 
 // Create menu button that will trigger rock() function. It will run animation sequence.
 // We will write (define) this function later. However, we should
-// forward-declare it in order to pass its reference to GEMItem constructor
+// forward-declare it in order to pass to GEMItem constructor
 void rock(); // Forward declaration
 GEMItem menuItemButton("Let's Rock!", rock);
 
@@ -177,7 +177,7 @@ void applyTempo() {
 // --- Animation draw routines
 
 // Draw sprite on screen
-void drawSprite(uint8_t PROGMEM *_splash, byte _mode) {
+void drawSprite(const uint8_t PROGMEM *_splash, byte _mode) {
   glcd.bitblt_P(glcd.xdim/2-(pgm_read_byte(_splash)+1)/2, glcd.ydim/2-(pgm_read_byte(_splash+1)+1)/2, _mode, _splash);
 }
 

--- a/examples/Example-03_Party-Hard/frames.h
+++ b/examples/Example-03_Party-Hard/frames.h
@@ -349,4 +349,4 @@ static const uint8_t partyFrame5 [] PROGMEM = {
 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 };
 
-void *frames[] = {partyFrame1, partyFrame2, partyFrame3, partyFrame4, partyFrame5};
+const uint8_t *frames[] = {partyFrame1, partyFrame2, partyFrame3, partyFrame4, partyFrame5};

--- a/src/GEM.cpp
+++ b/src/GEM.cpp
@@ -114,7 +114,7 @@ GEM::GEM(GLCD& glcd_, byte menuPointerType_, byte menuItemsPerScreen_, byte menu
 
 //====================== INIT OPERATIONS
 
-void GEM::setSplash(uint8_t PROGMEM *sprite) {
+void GEM::setSplash(const uint8_t PROGMEM *sprite) {
   _splash = sprite;
 }
 

--- a/src/GEM.h
+++ b/src/GEM.h
@@ -102,7 +102,7 @@ class GEM {
       default 86 (suitable for 128x64 screen with other variables at their default values; 86 - maximum value for 128x64 screen)
     */
     GEM(GLCD& glcd_, byte menuPointerType_ = GEM_POINTER_ROW, byte menuItemsPerScreen_ = 5, byte menuItemHeight_ = 10, byte menuPageScreenTopOffset_ = 10, byte menuValuesLeftOffset_ = 86);
-    void setSplash(uint8_t PROGMEM *sprite);             // Set custom sprite displayed as the splash screen when GEM is being initialized. Should be called before GEM::init().
+    void setSplash(const uint8_t PROGMEM *sprite);             // Set custom sprite displayed as the splash screen when GEM is being initialized. Should be called before GEM::init().
                                                          // The following is the format of the sprite as described in AltSerialGraphicLCD library documentation.
                                                          // The sprite commences with two bytes which are the width and height of the image in pixels.
                                                          // The pixel data is organised as rows of 8 vertical pixels per byte where the least significant bit (LSB)
@@ -132,7 +132,7 @@ class GEM {
     byte _menuItemInsetOffset;
     byte _menuItemTitleLength;
     byte _menuItemValueLength;
-    uint8_t PROGMEM *_splash;
+    const uint8_t PROGMEM *_splash;
     boolean _enableVersion = true;
 
     /* DRAW OPERATIONS */

--- a/src/GEMItem.cpp
+++ b/src/GEMItem.cpp
@@ -175,7 +175,7 @@ GEMItem::GEMItem(char* title_, GEMPage* linkedPage_)
   , type(GEM_ITEM_LINK)
 { }
 
-GEMItem::GEMItem(char* title_, void (&buttonAction_)())
+GEMItem::GEMItem(char* title_, void (*buttonAction_)())
   : title(title_)
   , buttonAction(buttonAction_)
   , type(GEM_ITEM_BUTTON)

--- a/src/GEMItem.h
+++ b/src/GEMItem.h
@@ -114,9 +114,9 @@ class GEMItem {
     /* 
       Constructor for menu item that represents button
       @param 'title_' - title of the menu item displayed on the screen
-      @param 'buttonAction_' - reference to function that will be executed when menu item is activated
+      @param 'buttonAction_' - pointer to function that will be executed when menu item is activated
     */
-    GEMItem(char* title_, void (&buttonAction_)());
+    GEMItem(char* title_, void (*buttonAction_)());
     void setReadonly(boolean mode = true);  // Explicitly set or unset readonly mode for variable that menu item is associated with
                                             // (relevant for GEM_VAL_INTEGER, GEM_VAL_BYTE, GEM_VAL_CHAR, GEM_VAL_BOOLEAN variable
                                             // menu items and GEM_VAL_SELECT option select)
@@ -130,7 +130,7 @@ class GEMItem {
     GEMSelect* select;
     GEMPage* linkedPage;
     GEMItem* menuItemNext;
-    void (&buttonAction)();
+    void (*buttonAction)();
     void (*saveAction)();
 };
   

--- a/src/GEMSelect.cpp
+++ b/src/GEMSelect.cpp
@@ -64,9 +64,9 @@ byte GEMSelect::getLength() {
 }
 
 int GEMSelect::getSelectedOptionNum(void* variable) {
-  SelectOptionInt* optsInt = _options;
-  SelectOptionByte* optsByte = _options;
-  SelectOptionChar* optsChar = _options;
+  SelectOptionInt* optsInt = (SelectOptionInt*)_options;
+  SelectOptionByte* optsByte = (SelectOptionByte*)_options;
+  SelectOptionChar* optsChar = (SelectOptionChar*)_options;
   boolean found = false;
   for (byte i=0; i<_length; i++) {
     switch (_type) {
@@ -91,10 +91,10 @@ char* GEMSelect::getSelectedOptionName(void* variable) {
 }
 
 char* GEMSelect::getOptionNameByIndex(int index) {
-  char* name;
-  SelectOptionInt* optsInt = _options;
-  SelectOptionByte* optsByte = _options;
-  SelectOptionChar* optsChar = _options;
+  const char* name;
+  SelectOptionInt* optsInt = (SelectOptionInt*)_options;
+  SelectOptionByte* optsByte = (SelectOptionByte*)_options;
+  SelectOptionChar* optsChar = (SelectOptionChar*)_options;
   switch (_type) {
     case GEM_VAL_INTEGER:
       name = (index > -1 && index < _length) ? optsInt[index].name : "";
@@ -106,13 +106,13 @@ char* GEMSelect::getOptionNameByIndex(int index) {
       name = (index > -1 && index < _length) ? optsChar[index].name : "";
       break;
   }
-  return name;
+  return const_cast<char*>(name);
 }
 
 void GEMSelect::setValue(void* variable, int index) {
-  SelectOptionInt* optsInt = _options;
-  SelectOptionByte* optsByte = _options;
-  SelectOptionChar* optsChar = _options;
+  SelectOptionInt* optsInt = (SelectOptionInt*)_options;
+  SelectOptionByte* optsByte = (SelectOptionByte*)_options;
+  SelectOptionChar* optsChar = (SelectOptionChar*)_options;
   if (index > -1 && index < _length) {
     switch (_type) {
       case GEM_VAL_INTEGER:

--- a/src/GEMSelect.h
+++ b/src/GEMSelect.h
@@ -38,7 +38,7 @@
 
 // Declaration of SelectOptionInt type
 struct SelectOptionInt {
-  char* name;  // Text label of the option as displayed in select
+  char* name;    // Text label of the option as displayed in select
   int val_int;   // Value of the option that is assigned to linked variable upon option selection
 };
 


### PR DESCRIPTION
Support for more restrictive compilers (w/o [`-fpermissive`](https://github.com/arduino/Arduino/issues/5361) flag), like those for SAMD based boards (e.g. Arduino Zero): explicit pointer and `const` type casting.