### PR TITLE
Code refactoring for better version separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Supports buttons that can invoke user-defined actions and create action-specific
 <img src="https://github.com/Spirik/GEM/wiki/images/party-hard-lcd_full-demo_p12_640x360_256c_mask.gif" width="640" height="360" alt="Party hard!" />
 </p>
 
-Requires either [AltSerialGraphicLCD](http://www.jasspa.com/serialGLCD.html) (since GEM ver. 1.0) or [U8g2](https://github.com/olikraus/U8g2_Arduino) (since GEM ver. 1.1) graphic libraries.
+Supports [AltSerialGraphicLCD](http://www.jasspa.com/serialGLCD.html) (since GEM ver. 1.0) and [U8g2](https://github.com/olikraus/U8g2_Arduino) (since GEM ver. 1.1) graphic libraries.
+
+> Note that both AltSerialGraphicLCD and U8g2 libraries are currently required, regardless of which one of them is actually used to drive display.
 
 > For use with AltSerialGraphicLCD library (by Jon Green) LCD screen must be equipped with [SparkFun Graphic LCD Serial Backpack](https://www.sparkfun.com/products/9352) and properly set up to operate using firmware provided with aforementioned library.
 
@@ -55,6 +57,8 @@ Library format is compatible with Arduino IDE 1.5.x+. There are two ways to inst
 - Using Library Manager (since Arduino IDE 1.6.2): navigate to `Sketch > Include Library > Manage Libraries` inside your Arduino IDE and search for GEM library, then click `Install`. (Alternatively you can add previously downloaded ZIP through `Sketch > Include Library > Add .ZIP Library` menu).
 
 Whichever option you choose you may need to reload IDE afterwards.
+
+Both [AltSerialGraphicLCD](http://www.jasspa.com/serialGLCD.html) and [U8g2](https://github.com/olikraus/U8g2_Arduino) libraries are required to be installed as well.
 
 How to use with AltSerialGraphicLCD
 -----------------------------------

--- a/src/GEM.cpp
+++ b/src/GEM.cpp
@@ -6,9 +6,8 @@
   Supports buttons that can invoke user-defined actions and create action-specific
   context, which can have its own enter (setup) and exit callbacks as well as loop function.
 
-  Requires AltSerialGraphicLCD library by Jon Green (http://www.jasspa.com/serialGLCD.html).
-  LCD screen must be equipped with SparkFun Graphic LCD Serial Backpack and properly set up
-  to operate using firmware provided with aforementioned library.
+  Supports AltSerialGraphicLCD library by Jon Green (http://www.jasspa.com/serialGLCD.html)
+  and U8g2 library by olikraus (https://github.com/olikraus/U8g2_Arduino).
 
   For documentation visit:
   https://github.com/Spirik/GEM
@@ -33,9 +32,6 @@
 
 #include <Arduino.h>
 #include "GEM.h"
-
-// Macro constant (alias) for current version of GEM library, printed on _splash screen
-#define GEM_VER "1.1"
 
 // Macro constants (aliases) for IDs of sprites of UI elements used to draw menu
 #define GEM_SPR_SELECT_ARROWS 0

--- a/src/GEM.h
+++ b/src/GEM.h
@@ -6,9 +6,8 @@
   Supports buttons that can invoke user-defined actions and create action-specific
   context, which can have its own enter (setup) and exit callbacks as well as loop function.
 
-  Requires AltSerialGraphicLCD library by Jon Green (http://www.jasspa.com/serialGLCD.html).
-  LCD screen must be equipped with SparkFun Graphic LCD Serial Backpack and properly set up
-  to operate using firmware provided with aforementioned library.
+  Supports AltSerialGraphicLCD library by Jon Green (http://www.jasspa.com/serialGLCD.html)
+  and U8g2 library by olikraus (https://github.com/olikraus/U8g2_Arduino).
 
   For documentation visit:
   https://github.com/Spirik/GEM
@@ -37,21 +36,7 @@
 #include <AltSerialGraphicLCD.h>
 #include "GEMPage.h"
 #include "GEMSelect.h"
-
-// Macro constant (alias) for supported length of the string (character sequence) variable of type char[GEM_STR_LEN]
-#define GEM_STR_LEN 17
-
-// Macro constants (aliases) for menu pointer visual appearance
-#define GEM_POINTER_DASH 0  // Current menu item is marked with pointer (filled square) to the left of its name
-#define GEM_POINTER_ROW 1   // Current menu item is marked with filled background
-
-// Macro constants (aliases) for supported types of associated with menu item variable
-#define GEM_VAL_INTEGER 0  // Associated variable is of type int
-#define GEM_VAL_BYTE 1     // Associated variable is of type byte
-#define GEM_VAL_CHAR 2     // Associated variable is of type char[GEM_STR_LEN]
-#define GEM_VAL_BOOLEAN 3  // Associated variable is of type boolean
-#define GEM_VAL_SELECT 4   // Associated variable is either of type int, byte or char[] with option select used to pick a predefined value from the list
-                           // (note that char[] array should be big enough to hold select option with the longest value)
+#include "constants.h"
 
 // Macro constants (aliases) for the keys (buttons) used to navigate and interact with menu
 #define GEM_KEY_NONE 0    // No key presses are detected

--- a/src/GEMItem.cpp
+++ b/src/GEMItem.cpp
@@ -8,9 +8,8 @@
   Supports buttons that can invoke user-defined actions and create action-specific
   context, which can have its own enter (setup) and exit callbacks as well as loop function.
 
-  Requires AltSerialGraphicLCD library by Jon Green (http://www.jasspa.com/serialGLCD.html).
-  LCD screen must be equipped with SparkFun Graphic LCD Serial Backpack and properly set up
-  to operate using firmware provided with aforementioned library.
+  Supports AltSerialGraphicLCD library by Jon Green (http://www.jasspa.com/serialGLCD.html)
+  and U8g2 library by olikraus (https://github.com/olikraus/U8g2_Arduino).
 
   For documentation visit:
   https://github.com/Spirik/GEM
@@ -35,7 +34,7 @@
 
 #include <Arduino.h>
 #include "GEMItem.h"
-#include "GEM.h"
+#include "constants.h"
 
 GEMItem::GEMItem(char* title_, byte& linkedVariable_, GEMSelect& select_, void (*saveAction_)())
   : title(title_)

--- a/src/GEMItem.h
+++ b/src/GEMItem.h
@@ -8,9 +8,8 @@
   Supports buttons that can invoke user-defined actions and create action-specific
   context, which can have its own enter (setup) and exit callbacks as well as loop function.
 
-  Requires AltSerialGraphicLCD library by Jon Green (http://www.jasspa.com/serialGLCD.html).
-  LCD screen must be equipped with SparkFun Graphic LCD Serial Backpack and properly set up
-  to operate using firmware provided with aforementioned library.
+  Supports AltSerialGraphicLCD library by Jon Green (http://www.jasspa.com/serialGLCD.html)
+  and U8g2 library by olikraus (https://github.com/olikraus/U8g2_Arduino).
 
   For documentation visit:
   https://github.com/Spirik/GEM

--- a/src/GEMPage.cpp
+++ b/src/GEMPage.cpp
@@ -8,9 +8,8 @@
   Supports buttons that can invoke user-defined actions and create action-specific
   context, which can have its own enter (setup) and exit callbacks as well as loop function.
 
-  Requires AltSerialGraphicLCD library by Jon Green (http://www.jasspa.com/serialGLCD.html).
-  LCD screen must be equipped with SparkFun Graphic LCD Serial Backpack and properly set up
-  to operate using firmware provided with aforementioned library.
+  Supports AltSerialGraphicLCD library by Jon Green (http://www.jasspa.com/serialGLCD.html)
+  and U8g2 library by olikraus (https://github.com/olikraus/U8g2_Arduino).
 
   For documentation visit:
   https://github.com/Spirik/GEM

--- a/src/GEMPage.h
+++ b/src/GEMPage.h
@@ -8,9 +8,8 @@
   Supports buttons that can invoke user-defined actions and create action-specific
   context, which can have its own enter (setup) and exit callbacks as well as loop function.
 
-  Requires AltSerialGraphicLCD library by Jon Green (http://www.jasspa.com/serialGLCD.html).
-  LCD screen must be equipped with SparkFun Graphic LCD Serial Backpack and properly set up
-  to operate using firmware provided with aforementioned library.
+  Supports AltSerialGraphicLCD library by Jon Green (http://www.jasspa.com/serialGLCD.html)
+  and U8g2 library by olikraus (https://github.com/olikraus/U8g2_Arduino).
 
   For documentation visit:
   https://github.com/Spirik/GEM

--- a/src/GEMSelect.cpp
+++ b/src/GEMSelect.cpp
@@ -8,9 +8,8 @@
   Supports buttons that can invoke user-defined actions and create action-specific
   context, which can have its own enter (setup) and exit callbacks as well as loop function.
 
-  Requires AltSerialGraphicLCD library by Jon Green (http://www.jasspa.com/serialGLCD.html).
-  LCD screen must be equipped with SparkFun Graphic LCD Serial Backpack and properly set up
-  to operate using firmware provided with aforementioned library.
+  Supports AltSerialGraphicLCD library by Jon Green (http://www.jasspa.com/serialGLCD.html)
+  and U8g2 library by olikraus (https://github.com/olikraus/U8g2_Arduino).
 
   For documentation visit:
   https://github.com/Spirik/GEM
@@ -35,7 +34,7 @@
 
 #include <Arduino.h>
 #include "GEMSelect.h"
-#include "GEM.h"
+#include "constants.h"
 
 GEMSelect::GEMSelect(byte length_, SelectOptionInt* options_)
   : _type(GEM_VAL_INTEGER)

--- a/src/GEM_u8g2.cpp
+++ b/src/GEM_u8g2.cpp
@@ -6,7 +6,8 @@
   Supports buttons that can invoke user-defined actions and create action-specific
   context, which can have its own enter (setup) and exit callbacks as well as loop function.
 
-  Requires U8g2 library by olikraus (https://github.com/olikraus/U8g2_Arduino).
+  Supports AltSerialGraphicLCD library by Jon Green (http://www.jasspa.com/serialGLCD.html)
+  and U8g2 library by olikraus (https://github.com/olikraus/U8g2_Arduino).
 
   For documentation visit:
   https://github.com/Spirik/GEM
@@ -31,9 +32,6 @@
 
 #include <Arduino.h>
 #include "GEM_u8g2.h"
-
-// Macro constant (alias) for current version of GEM library, printed on _splash screen
-#define GEM_VER "1.1"
 
 // Macro constants (aliases) for some of the ASCII character codes
 #define GEM_CHAR_CODE_9 57

--- a/src/GEM_u8g2.h
+++ b/src/GEM_u8g2.h
@@ -6,7 +6,8 @@
   Supports buttons that can invoke user-defined actions and create action-specific
   context, which can have its own enter (setup) and exit callbacks as well as loop function.
 
-  Requires U8g2 library by olikraus (https://github.com/olikraus/U8g2_Arduino).
+  Supports AltSerialGraphicLCD library by Jon Green (http://www.jasspa.com/serialGLCD.html)
+  and U8g2 library by olikraus (https://github.com/olikraus/U8g2_Arduino).
 
   For documentation visit:
   https://github.com/Spirik/GEM
@@ -29,33 +30,19 @@
   along with this library.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef HEADER_GEM
-#define HEADER_GEM
+#ifndef HEADER_GEM_U8G2
+#define HEADER_GEM_U8G2
 
 #include <U8g2lib.h>
 #include "GEMPage.h"
 #include "GEMSelect.h"
+#include "constants.h"
 
 // Macro constants (aliases) for u8g2 font families used to draw menu
 #define GEM_FONT_BIG        u8g2_font_6x12_tr
 #define GEM_FONT_SMALL      u8g2_font_tom_thumb_4x6_tr
 #define GEM_FONT_BIG_CYR    u8g2_font_6x12_t_cyrillic
 #define GEM_FONT_SMALL_CYR  u8g2_font_4x6_t_cyrillic
-
-// Macro constant (alias) for supported length of the string (character sequence) variable of type char[GEM_STR_LEN]
-#define GEM_STR_LEN 17
-
-// Macro constants (aliases) for menu pointer visual appearance
-#define GEM_POINTER_DASH 0  // Current menu item is marked with pointer (filled square) to the left of its name
-#define GEM_POINTER_ROW 1   // Current menu item is marked with filled background
-
-// Macro constants (aliases) for supported types of associated with menu item variable
-#define GEM_VAL_INTEGER 0  // Associated variable is of type int
-#define GEM_VAL_BYTE 1     // Associated variable is of type byte
-#define GEM_VAL_CHAR 2     // Associated variable is of type char[GEM_STR_LEN]
-#define GEM_VAL_BOOLEAN 3  // Associated variable is of type boolean
-#define GEM_VAL_SELECT 4   // Associated variable is either of type int, byte or char[] with option select used to pick a predefined value from the list
-                           // (note that char[] array should be big enough to hold select option with the longest value)
 
 // Macro constants (aliases) for the keys (buttons) used to navigate and interact with menu (mapped to corresponsding u8g2 constants)
 #define GEM_KEY_NONE    0                         // No key presses are detected

--- a/src/constants.h
+++ b/src/constants.h
@@ -1,6 +1,4 @@
 /*
-  GEMSelect - option select for GEM library.
-
   GEM (a.k.a. Good Enough Menu) - Arduino library for creation of graphic multi-level menu with
   editable menu items, such as variables (supports int, byte, boolean, char[17] data types) and
   option selects. User-defined callback function can be specified to invoke when menu item is saved.
@@ -32,49 +30,20 @@
   along with this library.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef HEADER_GEMSELECT
-#define HEADER_GEMSELECT
+// Macro constant (alias) for current version of GEM library, printed on _splash screen
+#define GEM_VER "1.1"
 
-// Declaration of SelectOptionInt type
-struct SelectOptionInt {
-  char* name;    // Text label of the option as displayed in select
-  int val_int;   // Value of the option that is assigned to linked variable upon option selection
-};
+// Macro constant (alias) for supported length of the string (character sequence) variable of type char[GEM_STR_LEN]
+#define GEM_STR_LEN 17
 
-// Declaration of SelectOptionByte type
-struct SelectOptionByte {
-  char* name;
-  byte val_byte;
-};
+// Macro constants (aliases) for menu pointer visual appearance
+#define GEM_POINTER_DASH 0  // Current menu item is marked with pointer (filled square) to the left of its name
+#define GEM_POINTER_ROW 1   // Current menu item is marked with filled background
 
-// Declaration of SelectOptionChar type
-struct SelectOptionChar {
-  char* name;
-  char* val_char;
-};
-
-// Declaration of GEMSelect class
-class GEMSelect {
-  friend class GEM;
-  friend class GEM_u8g2;
-  public:
-    /* 
-      @param 'length_' - length of the 'options_' array
-      @param 'options_' - array of the available options
-    */
-    GEMSelect(byte length_, SelectOptionInt* options_);
-    GEMSelect(byte length_, SelectOptionByte* options_);
-    GEMSelect(byte length_, SelectOptionChar* options_);
-  private:
-    byte _type;
-    byte _length;
-    void* _options;
-    byte getType();
-    byte getLength();
-    int getSelectedOptionNum(void* variable);
-    char* getSelectedOptionName(void* variable);
-    char* getOptionNameByIndex(int index);
-    void setValue(void* variable, int index);  // Assign value of the selected option to supplied variable
-};
-  
-#endif
+// Macro constants (aliases) for supported types of associated with menu item variable
+#define GEM_VAL_INTEGER 0  // Associated variable is of type int
+#define GEM_VAL_BYTE 1     // Associated variable is of type byte
+#define GEM_VAL_CHAR 2     // Associated variable is of type char[GEM_STR_LEN]
+#define GEM_VAL_BOOLEAN 3  // Associated variable is of type boolean
+#define GEM_VAL_SELECT 4   // Associated variable is either of type int, byte or char[] with option select used to pick a predefined value from the list
+                           // (note that char[] array should be big enough to hold select option with the longest value)


### PR DESCRIPTION
Small refactoring as an attempt to better separate AltSerialGraphicLCD and U8g2 versions:
* Removed direct includes of GEM.h from supplementary classes;
* Clarified Readme to state that both AltSerialGraphicLCD and U8g2 libraries are required to operate (at least in current version of GEM).

Hopefully, more elegant solution will be found later to eliminate current requirement of both libraries being installed at the same time (regardless of which of them is actually used to control a display).