### PR TITLE
Extend readonly state for menu links and buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -864,7 +864,7 @@ GEMItem menuItemSelect(title, linkedVariable, select[, saveCallback]);
 #### Link to menu page
 
 ```cpp
-GEMItem menuItemLink(title, linkedPage);
+GEMItem menuItemLink(title, linkedPage[, readonly]);
 ```
 
 * **title**  
@@ -875,10 +875,16 @@ GEMItem menuItemLink(title, linkedPage);
   *Type*: `GEMPage`  
   Menu page `GEMPage` that menu item is associated with.
 
+* **readonly** [*optional*]  
+  *Type*: `boolean`  
+  *Values*: `GEM_READONLY` (alias for `true`), `false`  
+  *Default*: `false`  
+  Sets readonly mode for the link (user won't be able to navigate to linked page).
+
 #### Button
 
 ```cpp
-GEMItem menuItemButton(title, buttonAction);
+GEMItem menuItemButton(title, buttonAction[, readonly]);
 ```
 
 * **title**  
@@ -888,6 +894,12 @@ GEMItem menuItemButton(title, buttonAction);
 * **buttonAction**  
   *Type*: `pointer to function`  
   Pointer to function that will be executed when menu item is activated. Action-specific [context](#appcontext) can be created, which can have its own enter (setup) and exit callbacks as well as loop function.
+
+* **readonly** [*optional*]  
+  *Type*: `boolean`  
+  *Values*: `GEM_READONLY` (alias for `true`), `false`  
+  *Default*: `false`  
+  Sets readonly mode for the button (user won't be able to call action associated with it).
 
 #### Constants
 
@@ -906,11 +918,11 @@ GEMItem menuItemButton(title, buttonAction);
 * **setReadonly(** _boolean_ mode = true **)**  
   *Accepts*: `boolean`  
   *Returns*: nothing  
-  Explicitly set (`setReadonly(true)`, or `setReadonly(GEM_READONLY)`, or `setReadonly()`) or unset (`setReadonly(false)`) readonly mode for variable that menu item is associated with. Relevant for `GEM_VAL_INTEGER`, `GEM_VAL_BYTE`, `GEM_VAL_CHAR`, `GEM_VAL_BOOLEAN` variable menu items and `GEM_VAL_SELECT` option select.
+  Explicitly set (`setReadonly(true)`, or `setReadonly(GEM_READONLY)`, or `setReadonly()`) or unset (`setReadonly(false)`) readonly mode for variable that menu item is associated with (relevant for `GEM_VAL_INTEGER`, `GEM_VAL_BYTE`, `GEM_VAL_CHAR`, `GEM_VAL_BOOLEAN` variable menu items and `GEM_VAL_SELECT` option select), or menu button `GEM_ITEM_BUTTON` and menu link `GEM_ITEM_LINK`, pressing of which won't result in any action, associated with them.
 
 * *boolean* **getReadonly()**  
   *Returns*: `boolean`  
-  Get readonly state for variable that menu item is associated with: `true` for readonly state, `false` otherwise.
+  Get readonly state for variable that menu item is associated with (as well as menu link or button): `true` for readonly state, `false` otherwise.
 
 
 ----------

--- a/src/GEM.cpp
+++ b/src/GEM.cpp
@@ -267,7 +267,12 @@ void GEM::printMenuItems() {
         break;
       case GEM_ITEM_LINK:
         _glcd.setX(5);
-        printMenuItemFull(menuItemTmp->title);
+        if (menuItemTmp->readonly) {
+          printMenuItemFull(menuItemTmp->title, -1);
+          _glcd.putstr("^");
+        } else {
+          printMenuItemFull(menuItemTmp->title);
+        }
         _glcd.drawSprite(_glcd.xdim-8, yDraw, GEM_SPR_ARROW_RIGHT, GLCD_MODE_NORMAL);
         break;
       case GEM_ITEM_BACK:
@@ -276,7 +281,12 @@ void GEM::printMenuItems() {
         break;
       case GEM_ITEM_BUTTON:
         _glcd.setX(11);
-        printMenuItemFull(menuItemTmp->title);
+        if (menuItemTmp->readonly) {
+          printMenuItemFull(menuItemTmp->title, -1);
+          _glcd.putstr("^");
+        } else {
+          printMenuItemFull(menuItemTmp->title);
+        }
         _glcd.drawSprite(5, yDraw, GEM_SPR_ARROW_BTN, GLCD_MODE_NORMAL);
         break;
     }
@@ -356,8 +366,10 @@ void GEM::menuItemSelect() {
       }
       break;
     case GEM_ITEM_LINK:
-      _menuPageCurrent = menuItemTmp->linkedPage;
-      drawMenu();
+      if (!menuItemTmp->readonly) {
+        _menuPageCurrent = menuItemTmp->linkedPage;
+        drawMenu();
+      }
       break;
     case GEM_ITEM_BACK:
       _menuPageCurrent->currentItemNum = (_menuPageCurrent->itemsCount > 1) ? 1 : 0;
@@ -365,7 +377,9 @@ void GEM::menuItemSelect() {
       drawMenu();
       break;
     case GEM_ITEM_BUTTON:
-      menuItemTmp->buttonAction();
+      if (!menuItemTmp->readonly) {
+        menuItemTmp->buttonAction();
+      }
       break;
   }
 }

--- a/src/GEMItem.cpp
+++ b/src/GEMItem.cpp
@@ -162,21 +162,24 @@ GEMItem::GEMItem(char* title_, boolean& linkedVariable_, boolean readonly_)
 
 //---
 
-GEMItem::GEMItem(char* title_, GEMPage& linkedPage_)
+GEMItem::GEMItem(char* title_, GEMPage& linkedPage_, boolean readonly_)
   : title(title_)
   , linkedPage(&linkedPage_)
+  , readonly(readonly_)
   , type(GEM_ITEM_LINK)
 { }
 
-GEMItem::GEMItem(char* title_, GEMPage* linkedPage_)
+GEMItem::GEMItem(char* title_, GEMPage* linkedPage_, boolean readonly_)
   : title(title_)
   , linkedPage(linkedPage_)
+  , readonly(readonly_)
   , type(GEM_ITEM_LINK)
 { }
 
-GEMItem::GEMItem(char* title_, void (*buttonAction_)())
+GEMItem::GEMItem(char* title_, void (*buttonAction_)(), boolean readonly_)
   : title(title_)
   , buttonAction(buttonAction_)
+  , readonly(readonly_)
   , type(GEM_ITEM_BUTTON)
 { }
 

--- a/src/GEMItem.h
+++ b/src/GEMItem.h
@@ -102,24 +102,31 @@ class GEMItem {
       Constructor for menu item that represents link to another menu page (via reference)
       @param 'title_' - title of the menu item displayed on the screen
       @param 'linkedPage_' - reference to GEMPage menu page that menu item is associated with
+      @param 'readonly_' (optional) - set readonly mode for the link (user won't be able to navigate to linked page)
+      values GEM_READONLY (alias for true)
     */
-    GEMItem(char* title_, GEMPage& linkedPage_);
+    GEMItem(char* title_, GEMPage& linkedPage_, boolean readonly_ = false);
     /* 
       Constructor for menu item that represents link to another menu page (via pointer)
       @param 'title_' - title of the menu item displayed on the screen
       @param 'linkedPage_' - pointer to GEMPage menu page that menu item is associated with
+      @param 'readonly_' (optional) - set readonly mode for the link (user won't be able to navigate to linked page)
+      values GEM_READONLY (alias for true)
     */
-    GEMItem(char* title_, GEMPage* linkedPage_);
+    GEMItem(char* title_, GEMPage* linkedPage_, boolean readonly_ = false);
     /* 
       Constructor for menu item that represents button
       @param 'title_' - title of the menu item displayed on the screen
       @param 'buttonAction_' - pointer to function that will be executed when menu item is activated
+      @param 'readonly_' (optional) - set readonly mode for the button (user won't be able to call action associated with it)
+      values GEM_READONLY (alias for true)
     */
-    GEMItem(char* title_, void (*buttonAction_)());
+    GEMItem(char* title_, void (*buttonAction_)(), boolean readonly_ = false);
     void setReadonly(boolean mode = true);  // Explicitly set or unset readonly mode for variable that menu item is associated with
                                             // (relevant for GEM_VAL_INTEGER, GEM_VAL_BYTE, GEM_VAL_CHAR, GEM_VAL_BOOLEAN variable
-                                            // menu items and GEM_VAL_SELECT option select)
-    boolean getReadonly();                  // Get readonly state for variable that menu item is associated with
+                                            // menu items and GEM_VAL_SELECT option select), or menu button GEM_ITEM_BUTTON and
+                                            // menu link GEM_ITEM_LINK, pressing of which won't result in any action, associated with them
+    boolean getReadonly();                  // Get readonly state for variable that menu item is associated with (as well as menu link or button)
   private:
     char* title;
     byte type;

--- a/src/GEM_u8g2.cpp
+++ b/src/GEM_u8g2.cpp
@@ -353,7 +353,12 @@ void GEM_u8g2::printMenuItems() {
         break;
       case GEM_ITEM_LINK:
         _u8g2.setCursor(5, yText);
-        printMenuItemFull(menuItemTmp->title);
+        if (menuItemTmp->readonly) {
+          printMenuItemFull(menuItemTmp->title, -1);
+          _u8g2.print("^");
+        } else {
+          printMenuItemFull(menuItemTmp->title);
+        }
         _u8g2.drawXBMP(_u8g2.getDisplayWidth() - 8, yDraw, arrowRight_width, arrowRight_height, arrowRight_bits);
         break;
       case GEM_ITEM_BACK:
@@ -362,7 +367,12 @@ void GEM_u8g2::printMenuItems() {
         break;
       case GEM_ITEM_BUTTON:
         _u8g2.setCursor(11, yText);
-        printMenuItemFull(menuItemTmp->title);
+        if (menuItemTmp->readonly) {
+          printMenuItemFull(menuItemTmp->title, -1);
+          _u8g2.print("^");
+        } else {
+          printMenuItemFull(menuItemTmp->title);
+        }
         _u8g2.drawXBMP(5, yDraw, arrowBtn_width, arrowBtn_height, arrowBtn_bits);
         break;
     }
@@ -425,8 +435,10 @@ void GEM_u8g2::menuItemSelect() {
       }
       break;
     case GEM_ITEM_LINK:
-      _menuPageCurrent = menuItemTmp->linkedPage;
-      drawMenu();
+      if (!menuItemTmp->readonly) {
+        _menuPageCurrent = menuItemTmp->linkedPage;
+        drawMenu();
+      }
       break;
     case GEM_ITEM_BACK:
       _menuPageCurrent->currentItemNum = (_menuPageCurrent->itemsCount > 1) ? 1 : 0;
@@ -434,7 +446,9 @@ void GEM_u8g2::menuItemSelect() {
       drawMenu();
       break;
     case GEM_ITEM_BUTTON:
-      menuItemTmp->buttonAction();
+      if (!menuItemTmp->readonly) {
+        menuItemTmp->buttonAction();
+      }
       break;
   }
 }


### PR DESCRIPTION
As suggested in #14:
* Readonly state is now available for menu links and buttons (pressing of which won't result in any action);
* Both `MenuItem` constructor and `MenuItem::setReadonly()` can be used to specify readonly state;
* Readme updated accordingly.