### PR TITLE
Toggle support for GEM versions via config.h

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ Supports buttons that can invoke user-defined actions and create action-specific
 
 Supports [AltSerialGraphicLCD](http://www.jasspa.com/serialGLCD.html) (since GEM ver. 1.0) and [U8g2](https://github.com/olikraus/U8g2_Arduino) (since GEM ver. 1.1) graphic libraries.
 
-> Note that both AltSerialGraphicLCD and U8g2 libraries are currently required, regardless of which one of them is actually used to drive display (although the one that is not used won't affect compiled sketch size).
+> Note that both AltSerialGraphicLCD and U8g2 libraries are required by default, regardless of which one of them is actually used to drive display (although the one that is not used won't affect compiled sketch size). However, it is possible (since GEM ver. 1.2.2) to exclude support for not used one. See [Configuration](#configuration) section for details.
 
 > For use with AltSerialGraphicLCD library (by Jon Green) LCD screen must be equipped with [SparkFun Graphic LCD Serial Backpack](https://www.sparkfun.com/products/9352) and properly set up to operate using firmware provided with aforementioned library.
 
 > Cyrillic is partially supported in U8g2 version of GEM (since 1.1). Can be used in menu title, menu item labels (including variables, buttons, and menu page links), and select options. Editable strings with Cyrillic characters are not supported.
 
-> Optional support for editable variables of `float` and `double` data types was added since version 1.2 of GEM. It is enabled by default, but can be disabled by editing [config.h](https://github.com/Spirik/GEM/blob/master/src/config.h) file that ships with the library. Disabling this feature may save considerable amount of program storage space. See [Floating-point variables](#floating-point-variables) for details.
+> Optional support for editable variables of `float` and `double` data types was added since version 1.2 of GEM. It is enabled by default, but can be disabled by editing [config.h](https://github.com/Spirik/GEM/blob/master/src/config.h) file that ships with the library. Disabling this feature may save considerable amount of program storage space. See [Floating-point variables](#floating-point-variables) section for details.
 
 * [When to use](#when-to-use)
 * [Structure](#structure)
@@ -33,6 +33,7 @@ Supports [AltSerialGraphicLCD](http://www.jasspa.com/serialGLCD.html) (since GEM
   * [GEMSelect](#gemselect)
   * [AppContext](#appcontext)
 * [Floating-point variables](#floating-point-variables)
+* [Configuration](#configuration)
 * [Examples](#examples)
 * [License](#license)
 * [**Wiki**](https://github.com/Spirik/GEM/wiki)
@@ -61,7 +62,7 @@ Library format is compatible with Arduino IDE 1.5.x+. There are two ways to inst
 
 Whichever option you choose you may need to reload IDE afterwards.
 
-Both [AltSerialGraphicLCD](http://www.jasspa.com/serialGLCD.html) and [U8g2](https://github.com/olikraus/U8g2_Arduino) libraries are required to be installed as well.
+Both [AltSerialGraphicLCD](http://www.jasspa.com/serialGLCD.html) and [U8g2](https://github.com/olikraus/U8g2_Arduino) libraries are required to be installed by default as well. However, it is possible (since GEM ver. 1.2.2) to exclude support fot not used one. See [Configuration](#configuration) section for details.
 
 How to use with AltSerialGraphicLCD
 -----------------------------------
@@ -1203,6 +1204,30 @@ to
 ```
 
 Note that option selects support `float` and `double` variables regardless of this setting.
+
+Configuration
+-----------
+It is possible to configure GEM library by excluding some features not needed in your project. That may help to save some additional program storage space. E.g., you can disable support for editable floating-point variables (see previous [section](#floating-point-variables)).
+
+You can also choose which version of GEM library (`AltSerialGraphicLCD` or `U8g2` based) should be compiled. That way, there won't be requirement to have both of the supported graphics libraries installed in the system at the same time (regardless of which one is actually used).
+
+For that, locate file [config.h](https://github.com/Spirik/GEM/blob/master/src/config.h) that comes with the library, open it and comment out corresponding inclusion.
+
+To disable `AltSerialGraphicLCD` support comment out the following line:
+
+```cpp
+#include "config/enable-glcd.h"
+```
+
+To disable `U8g2` support comment out the following line:
+
+```cpp
+#include "config/enable-u8g2.h"
+```
+
+More configuration options may be be added in the future.
+
+> Keep in mind that contents of the `config.h` file most likely will be reset to its default state after installing library update.
 
 Examples
 -----------

--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ Both [AltSerialGraphicLCD](http://www.jasspa.com/serialGLCD.html) and [U8g2](htt
 How to use with AltSerialGraphicLCD
 -----------------------------------
 
+<details>
+<summary>Click here to view</summary>
+
 ### Requirements
 
 GEM supports [AltSerialGraphicLCD](http://www.jasspa.com/serialGLCD.html) library. LCD screen must be equipped with [SparkFun Graphic LCD Serial Backpack](https://www.sparkfun.com/products/9352) and properly set up to operate using firmware provided with AltSerialGraphicLCD. Installation and configuration of it is covered in great detail in AltSerialGraphicLCD manual.
@@ -364,8 +367,13 @@ After compiling and uploading sketch to Arduino, wait while LCD screen boots and
 
 To learn more about GEM library, see the [Reference](#reference) section and visit [wiki](https://github.com/Spirik/GEM/wiki).
 
+</details>
+
 How to use with U8g2
 --------------------
+
+<details>
+<summary>Click here to view</summary>
 
 ### Requirements
 
@@ -574,6 +582,8 @@ After compiling and uploading sketch to Arduino, wait while LCD screen boots and
 ![Basic example](https://github.com/Spirik/GEM/wiki/images/gem-ex-01-basic-run.gif)
 
 To learn more about GEM library, see the [Reference](#reference) section and visit [wiki](https://github.com/Spirik/GEM/wiki).
+
+</details>
 
 Reference
 -----------

--- a/src/GEM.cpp
+++ b/src/GEM.cpp
@@ -33,6 +33,8 @@
 #include <Arduino.h>
 #include "GEM.h"
 
+#ifdef GEM_ENABLE_GLCD_VERSION
+
 // AVR-based Arduinos have suppoort for dtostrf, others require manual inclusion,
 // see https://github.com/plotly/arduino-api/issues/38#issuecomment-108987647
 #ifndef __AVR__
@@ -839,3 +841,5 @@ void GEM::dispatchKeyPress() {
 
   }
 }
+
+#endif

--- a/src/GEM.h
+++ b/src/GEM.h
@@ -33,11 +33,14 @@
 #ifndef HEADER_GEM
 #define HEADER_GEM
 
+#include "config.h"
+
+#ifdef GEM_ENABLE_GLCD_VERSION
+
 #include <AltSerialGraphicLCD.h>
 #include "GEMPage.h"
 #include "GEMSelect.h"
 #include "constants.h"
-#include "config.h"
 
 // Macro constants (aliases) for the keys (buttons) used to navigate and interact with menu
 #define GEM_KEY_NONE 0    // No key presses are detected
@@ -187,5 +190,7 @@ class GEM {
     byte _currentKey;
     void dispatchKeyPress();
 };
+
+#endif
 
 #endif

--- a/src/GEM_u8g2.cpp
+++ b/src/GEM_u8g2.cpp
@@ -33,6 +33,8 @@
 #include <Arduino.h>
 #include "GEM_u8g2.h"
 
+#ifdef GEM_ENABLE_U8G2_VERSION
+
 // AVR-based Arduinos have suppoort for dtostrf, others require manual inclusion,
 // see https://github.com/plotly/arduino-api/issues/38#issuecomment-108987647
 #ifndef __AVR__
@@ -917,3 +919,5 @@ void GEM_u8g2::dispatchKeyPress() {
 
   }
 }
+
+#endif

--- a/src/GEM_u8g2.h
+++ b/src/GEM_u8g2.h
@@ -33,11 +33,14 @@
 #ifndef HEADER_GEM_U8G2
 #define HEADER_GEM_U8G2
 
+#include "config.h"
+
+#ifdef GEM_ENABLE_U8G2_VERSION
+
 #include <U8g2lib.h>
 #include "GEMPage.h"
 #include "GEMSelect.h"
 #include "constants.h"
-#include "config.h"
 
 // Macro constants (aliases) for u8g2 font families used to draw menu
 #define GEM_FONT_BIG        u8g2_font_6x12_tr
@@ -200,5 +203,7 @@ class GEM_u8g2 {
     byte _currentKey;
     void dispatchKeyPress();
 };
+
+#endif
 
 #endif

--- a/src/config.h
+++ b/src/config.h
@@ -1,1 +1,3 @@
-#include "config/support-float-edit.h" // Support for editable float and double variables (option selects support them regardless of this setting)
+#include "config/enable-glcd.h"         // Enable AltSerialGraphicLCD version of GEM
+#include "config/enable-u8g2.h"         // Enable U8g2 version of GEM
+#include "config/support-float-edit.h"  // Support for editable float and double variables (option selects support them regardless of this setting)

--- a/src/config/enable-glcd.h
+++ b/src/config/enable-glcd.h
@@ -1,0 +1,3 @@
+#ifndef GEM_ENABLE_GLCD_VERSION
+#define GEM_ENABLE_GLCD_VERSION
+#endif

--- a/src/config/enable-u8g2.h
+++ b/src/config/enable-u8g2.h
@@ -1,0 +1,3 @@
+#ifndef GEM_ENABLE_U8G2_VERSION
+#define GEM_ENABLE_U8G2_VERSION
+#endif


### PR DESCRIPTION
* Choose which version of GEM library (`AltSerialGraphicLCD` or `U8g2` based) should be compiled via `config.h` file;
* Readme updated accordingly.