### PR TITLE
itoa support for non-avr boards

### DIFF
--- a/src/GEM.cpp
+++ b/src/GEM.cpp
@@ -36,9 +36,11 @@
 #ifdef GEM_ENABLE_GLCD_VERSION
 
 // AVR-based Arduinos have suppoort for dtostrf, others require manual inclusion,
-// see https://github.com/plotly/arduino-api/issues/38#issuecomment-108987647
+// see https://github.com/plotly/arduino-api/issues/38#issuecomment-108987647;
+// the same goes for itoa support on some non-AVR boards
 #ifndef __AVR__
 #include <avr/dtostrf.h>
+#include <itoa.h>
 #endif
 
 // Macro constants (aliases) for IDs of sprites of UI elements used to draw menu

--- a/src/GEM_u8g2.cpp
+++ b/src/GEM_u8g2.cpp
@@ -36,9 +36,11 @@
 #ifdef GEM_ENABLE_U8G2_VERSION
 
 // AVR-based Arduinos have suppoort for dtostrf, others require manual inclusion,
-// see https://github.com/plotly/arduino-api/issues/38#issuecomment-108987647
+// see https://github.com/plotly/arduino-api/issues/38#issuecomment-108987647;
+// the same goes for itoa support on some non-AVR boards
 #ifndef __AVR__
 #include <avr/dtostrf.h>
+#include <itoa.h>
 #endif
 
 // Macro constants (aliases) for some of the ASCII character codes


### PR DESCRIPTION
* Explicitly include `<itoa.h>` for non-AVR boards.