### PR TITLE
GEMPage exitAction callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -812,7 +812,7 @@ For more details on customization see corresponding section of the [wiki](https:
 Menu page holds menu items `GEMItem` and represents menu level. Menu can have multiple menu pages (linked to each other) with multiple menu items each. Object of class `GEMPage` defines as follows:
 
 ```cpp
-GEMPage menuPage(title);
+GEMPage menuPage(title[, exitAction]);
 ```
 
 * **title**  
@@ -820,6 +820,10 @@ GEMPage menuPage(title);
   Title of the menu page displayed at top of the screen.
   
   > **Note:** there is no explicit restriction on the length of the title. However, AltSerialGraphicLCD and U8g2 vesrions handle long titles differently. If title won't fit on a single line, it will overflow to the next line in AltSerialGraphicLCD version, but will be cropped at the edge of the screen in U8g2 version. In case of AltSerialGraphicLCD it is possible to accommodate multiline menu titles by enlarging `menuPageScreenTopOffset` when initializing `GEM` object.
+
+* **exitAction** [*optional*]  
+  *Type*: `pointer to function`  
+  Pointer to function that will be executed when `GEM_KEY_CANCEL` key is pressed while being on top level menu page (i.e. page that has no parent menu page). Action-specific [context](#appcontext) can be created, which can have its own enter (setup) and exit callbacks as well as loop function.
 
 #### Methods
 

--- a/README.md
+++ b/README.md
@@ -823,7 +823,7 @@ GEMPage menuPage(title[, exitAction]);
 
 * **exitAction** [*optional*]  
   *Type*: `pointer to function`  
-  Pointer to function that will be executed when `GEM_KEY_CANCEL` key is pressed while being on top level menu page (i.e. page that has no parent menu page). Action-specific [context](#appcontext) can be created, which can have its own enter (setup) and exit callbacks as well as loop function.
+  Pointer to function that will be executed when `GEM_KEY_CANCEL` key is pressed while being on top level menu page (i.e. page that has no parent menu page) and not in edit mode. Action-specific [context](#appcontext) can be created, which can have its own enter (setup) and exit callbacks as well as loop function.
 
 #### Methods
 

--- a/src/GEM.cpp
+++ b/src/GEM.cpp
@@ -833,6 +833,9 @@ void GEM::dispatchKeyPress() {
           if (_menuPageCurrent->getMenuItem(0)->type == GEM_ITEM_BACK) {
             _menuPageCurrent->currentItemNum = 0;
             menuItemSelect();
+          } else if (_menuPageCurrent->exitAction != nullptr) {
+            _menuPageCurrent->currentItemNum = 0;
+            _menuPageCurrent->exitAction();
           }
           break;
         case GEM_KEY_OK:

--- a/src/GEMPage.cpp
+++ b/src/GEMPage.cpp
@@ -35,8 +35,9 @@
 #include <Arduino.h>
 #include "GEMPage.h"
 
-GEMPage::GEMPage(char* title_)
+GEMPage::GEMPage(char* title_, void (*exitAction_)())
   : title(title_)
+  , exitAction(exitAction_)
 { }
 
 void GEMPage::addMenuItem(GEMItem& menuItem) {

--- a/src/GEMPage.h
+++ b/src/GEMPage.h
@@ -46,8 +46,9 @@ class GEMPage {
   public:
     /* 
       @param 'title_' - title of the menu page displayed at top of the screen
+      @param 'exitAction_' - pointer to callback function executed when GEM_KEY_CANCEL is pressed while being on top level menu page
     */
-    GEMPage(char* title_ = "");
+    GEMPage(char* title_ = "", void (*exitAction_)() = nullptr);
     void addMenuItem(GEMItem& menuItem);              // Add menu item to menu page
     void setParentMenuPage(GEMPage& parentMenuPage);  // Specify parent level menu page (to know where to go back to when pressing Back button)
     void setTitle(char* title_);                      // Set title of the menu page
@@ -65,6 +66,7 @@ class GEMPage {
     GEMItem* _menuItem;                                         // First menu item of the page (the following ones are linked from within one another)
     GEMItem _menuItemBack {"", static_cast<GEMPage*>(nullptr)}; // Local instance of Back button (created when parent level menu page is specified through
                                                                 // setParentMenuPage(); always becomes the first menu item in a list)
+    void (*exitAction)();
 };
   
 #endif

--- a/src/GEM_u8g2.cpp
+++ b/src/GEM_u8g2.cpp
@@ -911,6 +911,9 @@ void GEM_u8g2::dispatchKeyPress() {
           if (_menuPageCurrent->getMenuItem(0)->type == GEM_ITEM_BACK) {
             _menuPageCurrent->currentItemNum = 0;
             menuItemSelect();
+          } else if (_menuPageCurrent->exitAction != nullptr) {
+            _menuPageCurrent->currentItemNum = 0;
+            _menuPageCurrent->exitAction();
           }
           break;
         case GEM_KEY_OK:


### PR DESCRIPTION
* `GEMPage` constructor optional `exitAction` parameter added: pointer to a function that will be executed when `GEM_KEY_CANCEL` key is pressed while being on top level menu page;
* Readme updated accordingly.