### PR TITLE
setSplashDelay() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -743,11 +743,16 @@ For more details on customization see corresponding section of the [wiki](https:
   *Returns*: nothing  
   Set custom [XBM](https://en.wikipedia.org/wiki/X_BitMap) image displayed as the splash screen when GEM is being initialized. Should be called before `GEM_u8g2::init()`. For more details on splash customization and example refer to corresponding section of the [wiki](https://github.com/Spirik/GEM/wiki).
 
+* **setSplashDelay(** _uint16_t_ value **)**  
+  *Accepts*: `uint16_t`  
+  *Returns*: nothing  
+  Set splash screen delay (in ms). By default splash screen will be visible for 1000ms. Maximum supported value is 65535ms. Setting to 0 will disable splash screen. Should be called before `GEM::init()` and `GEM_u8g2::init()`.
+  > **Note:** internally splash screen delay is implemented via `delay()` function. This is the only place in library where `delay()` is utilized (aside of example sketches).
+
 * **hideVersion(** _boolean_ flag = true **)**  
   *Accepts*: `boolean`  
   *Returns*: nothing  
   Turn printing of the current GEM library version on splash screen off (`hideVersion()`) or back on (`hideVersion(false)`). By default the version is printed. Should be called before `GEM::init()` and `GEM_u8g2::init()`.
-  Set custom [XBM](https://en.wikipedia.org/wiki/X_BitMap) image displayed as the splash screen when GEM is being initialized. Should be called before `GEM_u8g2::init()`. For more details on splash customization and example refer to corresponding section of the [wiki](https://github.com/Spirik/GEM/wiki).
 
 * **enableCyrillic(** _boolean_ flag = true **)**  `U8g2 version only`  
   *Accepts*: `boolean`  

--- a/keywords.txt
+++ b/keywords.txt
@@ -26,6 +26,7 @@ SelectOptionDouble	KEYWORD1
 ####################################################
 
 setSplash	KEYWORD2
+setSplashDelay	KEYWORD2
 hideVersion	KEYWORD2
 enableCyrillic	KEYWORD2
 init	KEYWORD2

--- a/src/GEM.cpp
+++ b/src/GEM.cpp
@@ -12,7 +12,7 @@
   For documentation visit:
   https://github.com/Spirik/GEM
   
-  Copyright (c) 2018-2020 Alexander 'Spirik' Spiridonov
+  Copyright (c) 2018-2021 Alexander 'Spirik' Spiridonov
 
   This file is part of GEM library.
 
@@ -126,6 +126,10 @@ void GEM::setSplash(const uint8_t PROGMEM *sprite) {
   _splash = sprite;
 }
 
+void GEM::setSplashDelay(uint16_t value) {
+  _splashDelay = value;
+}
+
 void GEM::hideVersion(boolean flag) {
   _enableVersion = !flag;
 }
@@ -146,22 +150,27 @@ void GEM::init() {
   
   _menuItemTitleLength = (_menuValuesLeftOffset - 5) / _menuItemFont[_menuItemFontSize].width;
   _menuItemValueLength = (_glcd.xdim - _menuValuesLeftOffset - 6) / _menuItemFont[_menuItemFontSize].width;
-  _glcd.bitblt_P(_glcd.xdim/2-(pgm_read_byte(_splash)+1)/2, _glcd.ydim/2-(pgm_read_byte(_splash+1)+1)/2, GLCD_MODE_NORMAL, _splash);
+  
+  if (_splashDelay > 0) {
 
-  if (_enableVersion) {
-    delay(500);
-    _glcd.fontFace(1);
-    _glcd.setY(_glcd.ydim - 6);
-    if (_splash != logo) {
-      _glcd.setX(_glcd.xdim - strlen(GEM_VER)*4 - 12);
-      _glcd.putstr("GEM");
+    _glcd.bitblt_P(_glcd.xdim/2-(pgm_read_byte(_splash)+1)/2, _glcd.ydim/2-(pgm_read_byte(_splash+1)+1)/2, GLCD_MODE_NORMAL, _splash);
+
+    if (_enableVersion) {
+      delay(_splashDelay / 2);
+      _glcd.fontFace(1);
+      _glcd.setY(_glcd.ydim - 6);
+      if (_splash != logo) {
+        _glcd.setX(_glcd.xdim - strlen(GEM_VER)*4 - 12);
+        _glcd.putstr("GEM");
+      } else {
+        _glcd.setX(_glcd.xdim - strlen(GEM_VER)*4);
+      }
+      _glcd.putstr(GEM_VER);
+      delay(_splashDelay / 2);
     } else {
-      _glcd.setX(_glcd.xdim - strlen(GEM_VER)*4);
+      delay(_splashDelay);
     }
-    _glcd.putstr(GEM_VER);
-    delay(500);
-  } else {
-    delay(1000);
+
   }
 }
 

--- a/src/GEM.h
+++ b/src/GEM.h
@@ -12,7 +12,7 @@
   For documentation visit:
   https://github.com/Spirik/GEM
 
-  Copyright (c) 2018-2020 Alexander 'Spirik' Spiridonov
+  Copyright (c) 2018-2021 Alexander 'Spirik' Spiridonov
 
   This file is part of GEM library.
 
@@ -103,6 +103,7 @@ class GEM {
                                                          // by the next row of 8 vertical pixels and so on.
                                                          // Where the image height is not an exact multiple of 8 bits then any unused bits are typically set to zero
                                                          // (although this does not matter).
+    void setSplashDelay(uint16_t value);                 // Set splash screen delay. Default value 1000ms, max value 65535ms. Setting to 0 will disable splash screen. Should be called before GEM::init().
     void hideVersion(boolean flag = true);               // Turn printing of the current GEM library version on splash screen off or back on. Should be called before GEM::init().
     void init();                                         // Init the menu (load necessary sprites into RAM of the SparkFun Graphic LCD Serial Backpack, display GEM splash screen, etc.)
     void reInit();                                       // Reinitialize the menu (apply GEM specific settings to AltSerialGraphicLCD library)
@@ -135,6 +136,7 @@ class GEM {
     byte _menuItemTitleLength;
     byte _menuItemValueLength;
     const uint8_t PROGMEM *_splash;
+    uint16_t _splashDelay = 1000;
     boolean _enableVersion = true;
 
     /* DRAW OPERATIONS */

--- a/src/GEM_u8g2.cpp
+++ b/src/GEM_u8g2.cpp
@@ -12,7 +12,7 @@
   For documentation visit:
   https://github.com/Spirik/GEM
   
-  Copyright (c) 2018-2020 Alexander 'Spirik' Spiridonov
+  Copyright (c) 2020-2021 Alexander 'Spirik' Spiridonov
 
   This file is part of GEM library.
 
@@ -142,6 +142,10 @@ void GEM_u8g2::setSplash(byte width, byte height, const unsigned char U8X8_PROGM
   _splash = {width, height, image};
 }
 
+void GEM_u8g2::setSplashDelay(uint16_t value) {
+  _splashDelay = value;
+}
+
 void GEM_u8g2::hideVersion(boolean flag) {
   _enableVersion = !flag;
 }
@@ -165,33 +169,37 @@ void GEM_u8g2::init() {
   _menuItemTitleLength = (_menuValuesLeftOffset - 5) / _menuItemFont[_menuItemFontSize].width;
   _menuItemValueLength = (_u8g2.getDisplayWidth() - _menuValuesLeftOffset - 6) / _menuItemFont[_menuItemFontSize].width;
 
-  _u8g2.firstPage();
-  do {
-    _u8g2.drawXBMP((_u8g2.getDisplayWidth() - _splash.width) / 2, (_u8g2.getDisplayHeight() - _splash.height) / 2, _splash.width, _splash.height, _splash.image);
-  } while (_u8g2.nextPage());
+  if (_splashDelay > 0) {
 
-  if (_enableVersion) {
-    delay(500);
     _u8g2.firstPage();
     do {
       _u8g2.drawXBMP((_u8g2.getDisplayWidth() - _splash.width) / 2, (_u8g2.getDisplayHeight() - _splash.height) / 2, _splash.width, _splash.height, _splash.image);
-      _u8g2.setFont(_fontFamilies.small);
-      byte x = _u8g2.getDisplayWidth() - strlen(GEM_VER)*4;
-      byte y = _u8g2.getDisplayHeight() - 7;
-      if (_splash.image != logo_bits) {
-        _u8g2.setCursor(x - 12, y);
-        _u8g2.print("GEM");
-      } else {
-        _u8g2.setCursor(x, y);
-      }
-      _u8g2.print(GEM_VER);
     } while (_u8g2.nextPage());
-    delay(500);
-  } else {
-    delay(1000);
-  }
 
-  _u8g2.clear();
+    if (_enableVersion) {
+      delay(_splashDelay / 2);
+      _u8g2.firstPage();
+      do {
+        _u8g2.drawXBMP((_u8g2.getDisplayWidth() - _splash.width) / 2, (_u8g2.getDisplayHeight() - _splash.height) / 2, _splash.width, _splash.height, _splash.image);
+        _u8g2.setFont(_fontFamilies.small);
+        byte x = _u8g2.getDisplayWidth() - strlen(GEM_VER)*4;
+        byte y = _u8g2.getDisplayHeight() - 7;
+        if (_splash.image != logo_bits) {
+          _u8g2.setCursor(x - 12, y);
+          _u8g2.print("GEM");
+        } else {
+          _u8g2.setCursor(x, y);
+        }
+        _u8g2.print(GEM_VER);
+      } while (_u8g2.nextPage());
+      delay(_splashDelay / 2);
+    } else {
+      delay(_splashDelay);
+    }
+
+    _u8g2.clear();
+
+  }
 }
 
 void GEM_u8g2::reInit() {

--- a/src/GEM_u8g2.h
+++ b/src/GEM_u8g2.h
@@ -12,7 +12,7 @@
   For documentation visit:
   https://github.com/Spirik/GEM
 
-  Copyright (c) 2020 Alexander 'Spirik' Spiridonov
+  Copyright (c) 2020-2021 Alexander 'Spirik' Spiridonov
 
   This file is part of GEM library.
 
@@ -114,6 +114,7 @@ class GEM_u8g2 {
     /* INIT OPERATIONS */
 
     void setSplash(byte width, byte height, const unsigned char U8X8_PROGMEM *image); // Set custom XBM image displayed as the splash screen when GEM is being initialized. Should be called before GEM_u8g2::init().
+    void setSplashDelay(uint16_t value);                 // Set splash screen delay. Default value 1000ms, max value 65535ms. Setting to 0 will disable splash screen. Should be called before GEM_u8g2::init().
     void hideVersion(boolean flag = true);               // Turn printing of the current GEM library version on splash screen off or back on. Should be called before GEM_u8g2::init().
     void enableCyrillic(boolean flag = true);            // Enable Cyrillic set of fonts. Generally should be called before GEM_u8g2::init(). To revert to non-Cyrillic fonts pass false: enableCyrillic(false).
     void init();                                         // Init the menu (set necessary settings, display GEM splash screen, etc.)
@@ -149,6 +150,7 @@ class GEM_u8g2 {
     byte _menuItemTitleLength;
     byte _menuItemValueLength;
     Splash _splash;
+    uint16_t _splashDelay = 1000;
     boolean _enableVersion = true;
 
     /* DRAW OPERATIONS */


### PR DESCRIPTION
* `GEM::setSplashDelay()` and `GEM_u8g2::setSplashDelay()` methods to explicitly set duration of time splash screen will be visible during `init()` routine;
* Readme updated accordingly.