### PR TITLE
Better dtostrf inclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Supports [AltSerialGraphicLCD](http://www.jasspa.com/serialGLCD.html) (since GEM
   * [AppContext](#appcontext)
 * [Floating-point variables](#floating-point-variables)
 * [Configuration](#configuration)
+* [Compatibility](#compatibility)
 * [Examples](#examples)
 * [License](#license)
 * [**Wiki**](https://github.com/Spirik/GEM/wiki)
@@ -1273,6 +1274,10 @@ To disable `U8g2` support comment out the following line:
 More configuration options may be be added in the future.
 
 > Keep in mind that contents of the `config.h` file most likely will be reset to its default state after installing library update.
+
+Compatibility
+-----------
+When support for [Floating-point variables](#floating-point-variables) is enabled, GEM relies on `dtostrf()` function to handle conversion to a string, which may not be available for all of the architectures supported by Arduino by default. You may have to manually include support for it, e.g., via explicit inclusion of suitable version of `dtostrf.h` header file in `GEM.cpp` or `GEM_u8g2.cpp` source files. It is available for AVR-based boards by default and currently it is explicitly included for SAMD boards (e.g. with M0 chips). ESP32-based boards should be fine as well.
 
 Examples
 -----------

--- a/src/GEM.cpp
+++ b/src/GEM.cpp
@@ -35,12 +35,10 @@
 
 #ifdef GEM_ENABLE_GLCD_VERSION
 
-// AVR-based Arduinos have suppoort for dtostrf, others require manual inclusion,
-// see https://github.com/plotly/arduino-api/issues/38#issuecomment-108987647;
-// the same goes for itoa support on some non-AVR boards
-#ifndef __AVR__
+// AVR-based Arduinos have suppoort for dtostrf, some others may require manual inclusion (e.g. SAMD),
+// see https://github.com/plotly/arduino-api/issues/38#issuecomment-108987647
+#if defined(GEM_SUPPORT_FLOAT_EDIT) && (defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_SAM))
 #include <avr/dtostrf.h>
-#include <itoa.h>
 #endif
 
 // Macro constants (aliases) for IDs of sprites of UI elements used to draw menu

--- a/src/GEM_u8g2.cpp
+++ b/src/GEM_u8g2.cpp
@@ -35,12 +35,10 @@
 
 #ifdef GEM_ENABLE_U8G2_VERSION
 
-// AVR-based Arduinos have suppoort for dtostrf, others require manual inclusion,
-// see https://github.com/plotly/arduino-api/issues/38#issuecomment-108987647;
-// the same goes for itoa support on some non-AVR boards
-#ifndef __AVR__
+// AVR-based Arduinos have suppoort for dtostrf, some others may require manual inclusion (e.g. SAMD),
+// see https://github.com/plotly/arduino-api/issues/38#issuecomment-108987647
+#if defined(GEM_SUPPORT_FLOAT_EDIT) && (defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_SAM))
 #include <avr/dtostrf.h>
-#include <itoa.h>
 #endif
 
 // Macro constants (aliases) for some of the ASCII character codes


### PR DESCRIPTION
* Updates conditional inclusion of `avr/dtostrf.h` for SAMD boards;
* Readme section on platform compatibility added.