### PR TITLE
Fix compilation errors on ESP32 and ESP8266

### DIFF
--- a/src/GEMItem.cpp
+++ b/src/GEMItem.cpp
@@ -42,45 +42,45 @@ GEMItem::GEMItem(char* title_, byte& linkedVariable_, GEMSelect& select_, void (
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_SELECT)
+  , type(GEM_ITEM_VAL)
   , select(&select_)
   , saveAction(saveAction_)
-  , type(GEM_ITEM_VAL)
 { }
 
 GEMItem::GEMItem(char* title_, int& linkedVariable_, GEMSelect& select_, void (*saveAction_)())
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_SELECT)
+  , type(GEM_ITEM_VAL)
   , select(&select_)
   , saveAction(saveAction_)
-  , type(GEM_ITEM_VAL)
 { }
 
 GEMItem::GEMItem(char* title_, char* linkedVariable_, GEMSelect& select_, void (*saveAction_)())
   : title(title_)
   , linkedVariable(linkedVariable_)
   , linkedType(GEM_VAL_SELECT)
+  , type(GEM_ITEM_VAL)
   , select(&select_)
   , saveAction(saveAction_)
-  , type(GEM_ITEM_VAL)
 { }
 
 GEMItem::GEMItem(char* title_, float& linkedVariable_, GEMSelect& select_, void (*saveAction_)())
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_SELECT)
+  , type(GEM_ITEM_VAL)
   , select(&select_)
   , saveAction(saveAction_)
-  , type(GEM_ITEM_VAL)
 { }
 
 GEMItem::GEMItem(char* title_, double& linkedVariable_, GEMSelect& select_, void (*saveAction_)())
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_SELECT)
+  , type(GEM_ITEM_VAL)
   , select(&select_)
   , saveAction(saveAction_)
-  , type(GEM_ITEM_VAL)
 { }
 
 //---
@@ -89,45 +89,45 @@ GEMItem::GEMItem(char* title_, byte& linkedVariable_, GEMSelect& select_, boolea
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_SELECT)
-  , select(&select_)
-  , readonly(readonly_)
   , type(GEM_ITEM_VAL)
+  , readonly(readonly_)
+  , select(&select_)
 { }
 
 GEMItem::GEMItem(char* title_, int& linkedVariable_, GEMSelect& select_, boolean readonly_)
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_SELECT)
-  , select(&select_)
-  , readonly(readonly_)
   , type(GEM_ITEM_VAL)
+  , readonly(readonly_)
+  , select(&select_)
 { }
 
 GEMItem::GEMItem(char* title_, char* linkedVariable_, GEMSelect& select_, boolean readonly_)
   : title(title_)
   , linkedVariable(linkedVariable_)
   , linkedType(GEM_VAL_SELECT)
-  , select(&select_)
-  , readonly(readonly_)
   , type(GEM_ITEM_VAL)
+  , readonly(readonly_)
+  , select(&select_)
 { }
 
 GEMItem::GEMItem(char* title_, float& linkedVariable_, GEMSelect& select_, boolean readonly_)
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_SELECT)
-  , select(&select_)
-  , readonly(readonly_)
   , type(GEM_ITEM_VAL)
+  , readonly(readonly_)
+  , select(&select_)
 { }
 
 GEMItem::GEMItem(char* title_, double& linkedVariable_, GEMSelect& select_, boolean readonly_)
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_SELECT)
-  , select(&select_)
-  , readonly(readonly_)
   , type(GEM_ITEM_VAL)
+  , readonly(readonly_)
+  , select(&select_)
 { }
 
 //---
@@ -168,8 +168,8 @@ GEMItem::GEMItem(char* title_, float& linkedVariable_, void (*saveAction_)())
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_FLOAT)
-  , precision(GEM_FLOAT_PREC)
   , type(GEM_ITEM_VAL)
+  , precision(GEM_FLOAT_PREC)
   , saveAction(saveAction_)
 { }
 
@@ -177,8 +177,8 @@ GEMItem::GEMItem(char* title_, double& linkedVariable_, void (*saveAction_)())
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_DOUBLE)
-  , precision(GEM_DOUBLE_PREC)
   , type(GEM_ITEM_VAL)
+  , precision(GEM_DOUBLE_PREC)
   , saveAction(saveAction_)
 { }
 
@@ -188,73 +188,73 @@ GEMItem::GEMItem(char* title_, byte& linkedVariable_, boolean readonly_)
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_BYTE)
-  , readonly(readonly_)
   , type(GEM_ITEM_VAL)
+  , readonly(readonly_)
 { }
 
 GEMItem::GEMItem(char* title_, int& linkedVariable_, boolean readonly_)
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_INTEGER)
-  , readonly(readonly_)
   , type(GEM_ITEM_VAL)
+  , readonly(readonly_)
 { }
 
 GEMItem::GEMItem(char* title_, char* linkedVariable_, boolean readonly_)
   : title(title_)
   , linkedVariable(linkedVariable_)
   , linkedType(GEM_VAL_CHAR)
-  , readonly(readonly_)
   , type(GEM_ITEM_VAL)
+  , readonly(readonly_)
 { }
 
 GEMItem::GEMItem(char* title_, boolean& linkedVariable_, boolean readonly_)
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_BOOLEAN)
-  , readonly(readonly_)
   , type(GEM_ITEM_VAL)
+  , readonly(readonly_)
 { }
 
 GEMItem::GEMItem(char* title_, float& linkedVariable_, boolean readonly_)
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_FLOAT)
+  , type(GEM_ITEM_VAL)
   , precision(GEM_FLOAT_PREC)
   , readonly(readonly_)
-  , type(GEM_ITEM_VAL)
 { }
 
 GEMItem::GEMItem(char* title_, double& linkedVariable_, boolean readonly_)
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_DOUBLE)
+  , type(GEM_ITEM_VAL)
   , precision(GEM_DOUBLE_PREC)
   , readonly(readonly_)
-  , type(GEM_ITEM_VAL)
 { }
 
 //---
 
 GEMItem::GEMItem(char* title_, GEMPage& linkedPage_, boolean readonly_)
   : title(title_)
-  , linkedPage(&linkedPage_)
-  , readonly(readonly_)
   , type(GEM_ITEM_LINK)
+  , readonly(readonly_)
+  , linkedPage(&linkedPage_)
 { }
 
 GEMItem::GEMItem(char* title_, GEMPage* linkedPage_, boolean readonly_)
   : title(title_)
-  , linkedPage(linkedPage_)
-  , readonly(readonly_)
   , type(GEM_ITEM_LINK)
+  , readonly(readonly_)
+  , linkedPage(linkedPage_)
 { }
 
 GEMItem::GEMItem(char* title_, void (*buttonAction_)(), boolean readonly_)
   : title(title_)
-  , buttonAction(buttonAction_)
-  , readonly(readonly_)
   , type(GEM_ITEM_BUTTON)
+  , readonly(readonly_)
+  , buttonAction(buttonAction_)
 { }
 
 void GEMItem::setTitle(char* title_) {

--- a/src/GEMItem.h
+++ b/src/GEMItem.h
@@ -153,9 +153,9 @@ class GEMItem {
     boolean getHidden();                    // Get hidden state of the menu item
   private:
     char* title;
-    byte type;
     void* linkedVariable;
     byte linkedType;
+    byte type;
     byte precision = GEM_FLOAT_PREC;
     boolean readonly = false;
     boolean hidden = false;
@@ -163,9 +163,10 @@ class GEMItem {
     GEMPage* parentPage = nullptr;
     GEMPage* linkedPage;
     GEMItem* menuItemNext;
-    GEMItem* getMenuItemNext();             // Get next menu item, excluding hidden ones
     void (*buttonAction)();
     void (*saveAction)();
+
+    GEMItem* getMenuItemNext();             // Get next menu item, excluding hidden ones
 };
   
 #endif

--- a/src/GEMSelect.cpp
+++ b/src/GEMSelect.cpp
@@ -103,7 +103,8 @@ int GEMSelect::getSelectedOptionNum(void* variable) {
     }
     if (found) { return i; }
   }
-  if (!found) { return -1; }
+  // not found
+  return -1;
 }
 
 char* GEMSelect::getSelectedOptionName(void* variable) {


### PR DESCRIPTION
When compiling for ESP32, compiler emits errors for every `GEMItem` constructor for `-Werror=reorder` like this:
```
In file included from .pio/libdeps/dev/GEM/src/GEMPage.h:41:0,
                 from .pio/libdeps/dev/GEM/src/GEMItem.h:38,
                 from .pio/libdeps/dev/GEM/src/GEMItem.cpp:38:
.pio/libdeps/dev/GEM/src/GEMItem.h:160:24: error: 'GEMItem::readonly' will be initialized after [-Werror=reorder]
     boolean readonly = false;
                        ^
.pio/libdeps/dev/GEM/src/GEMItem.h:156:10: error:   'byte GEMItem::type' [-Werror=reorder]
     byte type;
          ^
.pio/libdeps/dev/GEM/src/GEMItem.cpp:253:1: error:   when initialized here [-Werror=reorder]
 GEMItem::GEMItem(char* title_, void (*buttonAction_)(), boolean readonly_)
 ^
```

When compiling for ESP8266, compiler emits error for `getSelectedOptionNum` not returning a value in all cases like this:
```
.pio/libdeps/8266/GEM/src/GEMSelect.cpp: In member function 'int GEMSelect::getSelectedOptionNum(void*)':
.pio/libdeps/8266/GEM/src/GEMSelect.cpp:107:1: error: control reaches end of non-void function [-Werror=return-type]
  107 | }
      | ^
```

This PR fixes these two problems, and I decided not to fix all the `char *` warnings...