### PR TITLE
Allow exclusion of libraries using defines

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -1,4 +1,15 @@
+#ifndef GEM_EXCLUDE_GLCD
 #include "config/enable-glcd.h"         // Enable AltSerialGraphicLCD version of GEM
+#endif
+
+#ifndef GEM_EXCLUDE_U8G2
 #include "config/enable-u8g2.h"         // Enable U8g2 version of GEM
+#endif
+
+#ifndef GEM_EXCLUDE_ADAFRUIT
 #include "config/enable-adafruit-gfx.h" // Enable Adafruit GFX version of GEM
+#endif
+
+#ifndef GEM_EXCLUDE_FLOAT_EDITS
 #include "config/support-float-edit.h"  // Support for editable float and double variables (option selects support them regardless of this setting)
+#endif


### PR DESCRIPTION
Thank you for creating this library!
I was building it using platform.io and preferred not to include libraries I wasn't using, especially since AltSerialGraphicLCD isn't available through the nifty `lib_deps` functionality in Platform.io

This change allows other Platform.io users to selectively exclude libraries like so:
```
[env:esp32dev]
[...]
lib_deps = 
	adafruit/Adafruit BusIO@^1.7.3
	adafruit/Adafruit ST7735 and ST7789 Library@^1.7.3
        spirik/GEM@^1.3.2
build_flags =
	-DGEM_EXCLUDE_GLCD
	-DGEM_EXCLUDE_U8G2
```

The existing instructions for your README's `Configuration` section still apply for Arduino IDE users.