### PR TITLE
Allow for inspection of menu state

### DIFF
--- a/src/GEM.cpp
+++ b/src/GEM.cpp
@@ -189,6 +189,72 @@ void GEM::setMenuPageCurrent(GEMPage& menuPageCurrent) {
   _menuPageCurrent = &menuPageCurrent;
 }
 
+bool GEM::isEditing() {
+  return _editValueMode;
+}
+
+int GEM::availableOptions() {
+  if(_editValueMode) {
+    switch (_editValueType) {
+      case GEM_VAL_INTEGER:
+      case GEM_VAL_BYTE:
+        // position 0 allows 0-9, ' ', '-'
+        // later positions don't allow '-'
+        return _editValueCursorPosition == 0 ? 12 : 11;
+      case GEM_VAL_CHAR:
+        return GEM_CHAR_CODE_TILDA - GEM_CHAR_CODE_SPACE;
+      case GEM_VAL_SELECT:
+        {
+          GEMItem* menuItemTmp = _menuPageCurrent->getCurrentMenuItem();
+          GEMSelect* select = menuItemTmp->select;
+          return select->getLength();
+        }
+      case GEM_VAL_FLOAT:
+      case GEM_VAL_DOUBLE:
+        // position 0 allows 0-9, ' ', '-'
+        // later positions don't allow '-' but do allow '.'
+        return 12;
+    }
+  } else {
+    return _menuPageCurrent->itemsCount;
+  }
+}
+
+int GEM::currentOption() {
+  if(_editValueMode) {
+    char chr;
+    switch (_editValueType) {
+      case GEM_VAL_INTEGER:
+      case GEM_VAL_BYTE:
+      case GEM_VAL_FLOAT:
+      case GEM_VAL_DOUBLE:
+        chr = _valueString[_editValueVirtualCursorPosition];
+        switch (chr) {
+          case GEM_CHAR_CODE_MINUS:
+            return 11;
+          case GEM_CHAR_CODE_SPACE:
+            // in position 0 we have minus before space
+            return (_editValueCursorPosition == 0) ? 12 : 11;
+          case GEM_CHAR_CODE_DOT:
+            return 13;
+          default:
+            return chr - GEM_CHAR_CODE_0;
+        }
+      case GEM_VAL_CHAR:
+        chr = _valueString[_editValueVirtualCursorPosition];
+        return chr - GEM_CHAR_CODE_SPACE;
+      case GEM_VAL_SELECT:
+        {
+          GEMItem* menuItemTmp = _menuPageCurrent->getCurrentMenuItem();
+          GEMSelect* select = menuItemTmp->select;
+          return _valueSelectNum = select->getSelectedOptionNum(menuItemTmp->linkedVariable);
+        }
+    }
+  } else {
+    return _menuPageCurrent->currentItemNum;
+  }
+}
+
 //====================== CONTEXT OPERATIONS
 
 void GEM::clearContext() {
@@ -413,6 +479,7 @@ void GEM::menuItemSelect() {
     case GEM_ITEM_VAL:
       if (!menuItemTmp->readonly) {
         enterEditValueMode();
+        if (menuItemTmp->enterAction) menuItemTmp->enterAction(menuItemTmp);
       }
       break;
     case GEM_ITEM_LINK:

--- a/src/GEM.h
+++ b/src/GEM.h
@@ -111,6 +111,9 @@ class GEM {
     void init();                                         // Init the menu (load necessary sprites into RAM of the SparkFun Graphic LCD Serial Backpack, display GEM splash screen, etc.)
     void reInit();                                       // Reinitialize the menu (apply GEM specific settings to AltSerialGraphicLCD library)
     void setMenuPageCurrent(GEMPage& menuPageCurrent);   // Set supplied menu page as current
+    bool isEditing();
+    int availableOptions();
+    int currentOption();
 
     /* CONTEXT OPERATIONS */
 

--- a/src/GEMItem.cpp
+++ b/src/GEMItem.cpp
@@ -38,49 +38,54 @@
 #include "GEMItem.h"
 #include "constants.h"
 
-GEMItem::GEMItem(const char* title_, byte& linkedVariable_, GEMSelect& select_, void (*saveAction_)())
+GEMItem::GEMItem(const char* title_, byte& linkedVariable_, GEMSelect& select_, void (*saveAction_)(), void (*enterAction_)(GEMItem *item))
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_SELECT)
   , type(GEM_ITEM_VAL)
   , select(&select_)
   , saveAction(saveAction_)
+  , enterAction(enterAction_)
 { }
 
-GEMItem::GEMItem(const char* title_, int& linkedVariable_, GEMSelect& select_, void (*saveAction_)())
+GEMItem::GEMItem(const char* title_, int& linkedVariable_, GEMSelect& select_, void (*saveAction_)(), void (*enterAction_)(GEMItem *item))
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_SELECT)
   , type(GEM_ITEM_VAL)
   , select(&select_)
   , saveAction(saveAction_)
+  , enterAction(enterAction_)
 { }
 
-GEMItem::GEMItem(const char* title_, char* linkedVariable_, GEMSelect& select_, void (*saveAction_)())
+GEMItem::GEMItem(const char* title_, char* linkedVariable_, GEMSelect& select_, void (*saveAction_)(), void (*enterAction_)(GEMItem *item))
   : title(title_)
   , linkedVariable(linkedVariable_)
   , linkedType(GEM_VAL_SELECT)
   , type(GEM_ITEM_VAL)
   , select(&select_)
   , saveAction(saveAction_)
+  , enterAction(enterAction_)
 { }
 
-GEMItem::GEMItem(const char* title_, float& linkedVariable_, GEMSelect& select_, void (*saveAction_)())
+GEMItem::GEMItem(const char* title_, float& linkedVariable_, GEMSelect& select_, void (*saveAction_)(), void (*enterAction_)(GEMItem *item))
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_SELECT)
   , type(GEM_ITEM_VAL)
   , select(&select_)
   , saveAction(saveAction_)
+  , enterAction(enterAction_)
 { }
 
-GEMItem::GEMItem(const char* title_, double& linkedVariable_, GEMSelect& select_, void (*saveAction_)())
+GEMItem::GEMItem(const char* title_, double& linkedVariable_, GEMSelect& select_, void (*saveAction_)(), void (*enterAction_)(GEMItem *item))
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_SELECT)
   , type(GEM_ITEM_VAL)
   , select(&select_)
   , saveAction(saveAction_)
+  , enterAction(enterAction_)
 { }
 
 //---
@@ -132,48 +137,53 @@ GEMItem::GEMItem(const char* title_, double& linkedVariable_, GEMSelect& select_
 
 //---
 
-GEMItem::GEMItem(const char* title_, byte& linkedVariable_, void (*saveAction_)())
+GEMItem::GEMItem(const char* title_, byte& linkedVariable_, void (*saveAction_)(), void (*enterAction_)(GEMItem *item))
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_BYTE)
   , type(GEM_ITEM_VAL)
   , saveAction(saveAction_)
+  , enterAction(enterAction_)
 { }
 
-GEMItem::GEMItem(const char* title_, int& linkedVariable_, void (*saveAction_)())
+GEMItem::GEMItem(const char* title_, int& linkedVariable_, void (*saveAction_)(), void (*enterAction_)(GEMItem *item))
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_INTEGER)
   , type(GEM_ITEM_VAL)
   , saveAction(saveAction_)
+  , enterAction(enterAction_)
 { }
 
-GEMItem::GEMItem(const char* title_, char* linkedVariable_, void (*saveAction_)())
+GEMItem::GEMItem(const char* title_, char* linkedVariable_, void (*saveAction_)(), void (*enterAction_)(GEMItem *item))
   : title(title_)
   , linkedVariable(linkedVariable_)
   , linkedType(GEM_VAL_CHAR)
   , type(GEM_ITEM_VAL)
   , saveAction(saveAction_)
+  , enterAction(enterAction_)
 { }
 
-GEMItem::GEMItem(const char* title_, boolean& linkedVariable_, void (*saveAction_)())
+GEMItem::GEMItem(const char* title_, boolean& linkedVariable_, void (*saveAction_)(), void (*enterAction_)(GEMItem *item))
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_BOOLEAN)
   , type(GEM_ITEM_VAL)
   , saveAction(saveAction_)
+  , enterAction(enterAction_)
 { }
 
-GEMItem::GEMItem(const char* title_, float& linkedVariable_, void (*saveAction_)())
+GEMItem::GEMItem(const char* title_, float& linkedVariable_, void (*saveAction_)(), void (*enterAction_)(GEMItem *item))
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_FLOAT)
   , type(GEM_ITEM_VAL)
   , precision(GEM_FLOAT_PREC)
   , saveAction(saveAction_)
+  , enterAction(enterAction_)
 { }
 
-GEMItem::GEMItem(const char* title_, double& linkedVariable_, void (*saveAction_)())
+GEMItem::GEMItem(const char* title_, double& linkedVariable_, void (*saveAction_)(), void (*enterAction_)(GEMItem *item))
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_DOUBLE)

--- a/src/GEMItem.h
+++ b/src/GEMItem.h
@@ -70,11 +70,11 @@ class GEMItem {
       @param 'select_' - reference to GEMSelect option select
       @param 'saveAction_' - pointer to callback function executed when associated variable is successfully saved
     */
-    GEMItem(const char* title_, byte& linkedVariable_, GEMSelect& select_, void (*saveAction_)());
-    GEMItem(const char* title_, int& linkedVariable_, GEMSelect& select_, void (*saveAction_)());
-    GEMItem(const char* title_, char* linkedVariable_, GEMSelect& select_, void (*saveAction_)());
-    GEMItem(const char* title_, float& linkedVariable_, GEMSelect& select_, void (*saveAction_)());
-    GEMItem(const char* title_, double& linkedVariable_, GEMSelect& select_, void (*saveAction_)());
+    GEMItem(const char* title_, byte& linkedVariable_, GEMSelect& select_, void (*saveAction_)(), void (*enterAction_)(GEMItem *item) = nullptr);
+    GEMItem(const char* title_, int& linkedVariable_, GEMSelect& select_, void (*saveAction_)(), void (*enterAction_)(GEMItem *item) = nullptr);
+    GEMItem(const char* title_, char* linkedVariable_, GEMSelect& select_, void (*saveAction_)(), void (*enterAction_)(GEMItem *item) = nullptr);
+    GEMItem(const char* title_, float& linkedVariable_, GEMSelect& select_, void (*saveAction_)(), void (*enterAction_)(GEMItem *item) = nullptr);
+    GEMItem(const char* title_, double& linkedVariable_, GEMSelect& select_, void (*saveAction_)(), void (*enterAction_)(GEMItem *item) = nullptr);
     /* 
       Constructors for menu item that represents option select, w/o callback
       @param 'title_' - title of the menu item displayed on the screen
@@ -95,12 +95,12 @@ class GEMItem {
       @param 'linkedVariable_' - reference to variable that menu item is associated with (either byte, int, char*, boolean, float, or double)
       @param 'saveAction_' - pointer to callback function executed when associated variable is successfully saved
     */
-    GEMItem(const char* title_, byte& linkedVariable_, void (*saveAction_)());
-    GEMItem(const char* title_, int& linkedVariable_, void (*saveAction_)());
-    GEMItem(const char* title_, char* linkedVariable_, void (*saveAction_)());
-    GEMItem(const char* title_, boolean& linkedVariable_, void (*saveAction_)());
-    GEMItem(const char* title_, float& linkedVariable_, void (*saveAction_)());
-    GEMItem(const char* title_, double& linkedVariable_, void (*saveAction_)());
+    GEMItem(const char* title_, byte& linkedVariable_, void (*saveAction_)(), void (*enterAction_)(GEMItem *item) = nullptr);
+    GEMItem(const char* title_, int& linkedVariable_, void (*saveAction_)(), void (*enterAction_)(GEMItem *item) = nullptr);
+    GEMItem(const char* title_, char* linkedVariable_, void (*saveAction_)(), void (*enterAction_)(GEMItem *item) = nullptr);
+    GEMItem(const char* title_, boolean& linkedVariable_, void (*saveAction_)(), void (*enterAction_)(GEMItem *item) = nullptr);
+    GEMItem(const char* title_, float& linkedVariable_, void (*saveAction_)(), void (*enterAction_)(GEMItem *item) = nullptr);
+    GEMItem(const char* title_, double& linkedVariable_, void (*saveAction_)(), void (*enterAction_)(GEMItem *item) = nullptr);
     /* 
       Constructors for menu item that represents variable, w/o callback
       @param 'title_' - title of the menu item displayed on the screen
@@ -165,6 +165,7 @@ class GEMItem {
     GEMItem* menuItemNext;
     void (*buttonAction)();
     void (*saveAction)();
+    void (*enterAction)(GEMItem *item);
     GEMItem* getMenuItemNext();             // Get next menu item, excluding hidden ones
 };
   

--- a/src/GEM_adafruit_gfx.cpp
+++ b/src/GEM_adafruit_gfx.cpp
@@ -198,6 +198,72 @@ void GEM_adafruit_gfx::setMenuPageCurrent(GEMPage& menuPageCurrent) {
   _menuPageCurrent = &menuPageCurrent;
 }
 
+bool GEM_adafruit_gfx::isEditing() {
+  return _editValueMode;
+}
+
+int GEM_adafruit_gfx::availableOptions() {
+  if(_editValueMode) {
+    switch (_editValueType) {
+      case GEM_VAL_INTEGER:
+      case GEM_VAL_BYTE:
+        // position 0 allows 0-9, ' ', '-'
+        // later positions don't allow '-'
+        return _editValueCursorPosition == 0 ? 12 : 11;
+      case GEM_VAL_CHAR:
+        return GEM_CHAR_CODE_TILDA - GEM_CHAR_CODE_SPACE;
+      case GEM_VAL_SELECT:
+        {
+          GEMItem* menuItemTmp = _menuPageCurrent->getCurrentMenuItem();
+          GEMSelect* select = menuItemTmp->select;
+          return select->getLength();
+        }
+      case GEM_VAL_FLOAT:
+      case GEM_VAL_DOUBLE:
+        // position 0 allows 0-9, ' ', '-'
+        // later positions don't allow '-' but do allow '.'
+        return 12;
+    }
+  } else {
+    return _menuPageCurrent->itemsCount;
+  }
+}
+
+int GEM_adafruit_gfx::currentOption() {
+  if(_editValueMode) {
+    char chr;
+    switch (_editValueType) {
+      case GEM_VAL_INTEGER:
+      case GEM_VAL_BYTE:
+      case GEM_VAL_FLOAT:
+      case GEM_VAL_DOUBLE:
+        chr = _valueString[_editValueVirtualCursorPosition];
+        switch (chr) {
+          case GEM_CHAR_CODE_MINUS:
+            return 11;
+          case GEM_CHAR_CODE_SPACE:
+            // in position 0 we have minus before space
+            return (_editValueCursorPosition == 0) ? 12 : 11;
+          case GEM_CHAR_CODE_DOT:
+            return 13;
+          default:
+            return chr - GEM_CHAR_CODE_0;
+        }
+      case GEM_VAL_CHAR:
+        chr = _valueString[_editValueVirtualCursorPosition];
+        return chr - GEM_CHAR_CODE_SPACE;
+      case GEM_VAL_SELECT:
+        {
+          GEMItem* menuItemTmp = _menuPageCurrent->getCurrentMenuItem();
+          GEMSelect* select = menuItemTmp->select;
+          return _valueSelectNum = select->getSelectedOptionNum(menuItemTmp->linkedVariable);
+        }
+    }
+  } else {
+    return _menuPageCurrent->currentItemNum;
+  }
+}
+
 //====================== CONTEXT OPERATIONS
 
 void GEM_adafruit_gfx::clearContext() {
@@ -442,6 +508,7 @@ void GEM_adafruit_gfx::menuItemSelect() {
     case GEM_ITEM_VAL:
       if (!menuItemTmp->readonly) {
         enterEditValueMode();
+        if (menuItemTmp->enterAction) menuItemTmp->enterAction(menuItemTmp);
       }
       break;
     case GEM_ITEM_LINK:

--- a/src/GEM_adafruit_gfx.h
+++ b/src/GEM_adafruit_gfx.h
@@ -127,6 +127,9 @@ class GEM_adafruit_gfx {
     void init();                                         // Init the menu (load necessary sprites into RAM of the SparkFun Graphic LCD Serial Backpack, display GEM splash screen, etc.)
     void reInit();                                       // Reinitialize the menu (apply GEM specific settings to AltSerialGraphicLCD library)
     void setMenuPageCurrent(GEMPage& menuPageCurrent);   // Set supplied menu page as current
+    bool isEditing();
+    int availableOptions();
+    int currentOption();
 
     /* CONTEXT OPERATIONS */
 

--- a/src/GEM_u8g2.h
+++ b/src/GEM_u8g2.h
@@ -123,6 +123,9 @@ class GEM_u8g2 {
     void init();                                         // Init the menu (set necessary settings, display GEM splash screen, etc.)
     void reInit();                                       // Reinitialize the menu (call U8g2::initDisplay() and then reapply GEM specific settings)
     void setMenuPageCurrent(GEMPage& menuPageCurrent);   // Set supplied menu page as current
+    bool isEditing();
+    int availableOptions();
+    int currentOption();
 
     /* CONTEXT OPERATIONS */
 


### PR DESCRIPTION
I needed these methods in order to connect a fancy rotary input controller to this menu and thought I'd see if you wanted to merge those in. I've attempted to keep the modifications as small as possible while unlocking the functionality I needed. 

Taken together, these changes allow me to configure my input controller for the number of items currently on screen as well as the selected item. This works both when a menu is shown or when editing content.

The new methods are:
`bool GEM::isEditing()` <- whether we're selecting or editing
`int GEM::availableOptions()` <- the count of options in the current state (e.g. 5)
`int GEM::currentOption()` <- the (e.g. 2/5)

Further, the `GemItems` constructors now take an optional pointer to a `void enterAction(GemItem *item)` callback which allows us to react to the beginning of an edit operation (much like the `saveAction` allows us to ract to the end of an edit operation).

I think this might make a reasonably unobtrusive addition and would be happy to make modifications you deem necessary. As you see I have not updated any documentation.