### PR TITLE
Fix compilation warnings on RP2040 and nRF52840

### DIFF
--- a/README.md
+++ b/README.md
@@ -1765,9 +1765,9 @@ build_flags =
 
 Compatibility
 -----------
-ESP32 and ESP8266 based boards are not supported in AltSerialGraphicLCD version of GEM: this library should be commented out in [config.h](https://github.com/Spirik/GEM/blob/master/src/config.h) before compiling.
+Some boards (e.g. ESP32, ESP8266, RP2040, nRF52840, etc. based boards) are not supported in AltSerialGraphicLCD version of GEM: this library should be commented out in [config.h](https://github.com/Spirik/GEM/blob/master/src/config.h) before compiling.
 
-When support for [Floating-point variables](#floating-point-variables) is enabled, GEM relies on `dtostrf()` function to handle conversion to a string, which may not be available for all of the architectures supported by Arduino by default. You may have to manually include support for it, e.g., via explicit inclusion of suitable version of `dtostrf.h` header file in `GEM.cpp`, `GEM_u8g2.cpp` or `GEM_adafruit_gfx.cpp` source files. It is available for AVR-based boards by default and currently it is explicitly included for SAMD boards (e.g. with M0 chips). ESP32-based boards should be fine as well.
+When support for [Floating-point variables](#floating-point-variables) is enabled, GEM relies on `dtostrf()` function to handle conversion to a string, which may not be available for all of the architectures supported by Arduino by default. You may have to manually include support for it, e.g., via explicit inclusion of suitable version of `dtostrf.h` header file in `GEM.cpp`, `GEM_u8g2.cpp` or `GEM_adafruit_gfx.cpp` source files. It is available for AVR-based boards by default and currently it is explicitly included for SAMD boards (e.g. with M0 chips), RP2040 and nRF52840 based boards. ESP32 based boards should be fine as well.
 
 > **Note:** there are reports of possible compatibility issues with some ESP32 based boards resulting in `flash read err, 1000` message after flashing compiled sketch (some users find it is possible to reflash the board afterwards to restore its functionality, some don't). Check this [thread](https://github.com/Spirik/GEM/issues/55) for more details.
 

--- a/src/GEM.cpp
+++ b/src/GEM.cpp
@@ -39,7 +39,7 @@
 
 // AVR-based Arduinos have suppoort for dtostrf, some others may require manual inclusion (e.g. SAMD),
 // see https://github.com/plotly/arduino-api/issues/38#issuecomment-108987647
-#if defined(GEM_SUPPORT_FLOAT_EDIT) && (defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_SAM) || defined(ARDUINO_ARCH_RP2040))
+#if defined(GEM_SUPPORT_FLOAT_EDIT) && (defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_SAM) || defined(ARDUINO_ARCH_RP2040) || defined(ARDUINO_ARCH_NRF52840))
 #include <avr/dtostrf.h>
 #endif
 

--- a/src/GEM.cpp
+++ b/src/GEM.cpp
@@ -679,8 +679,6 @@ void GEM::nextEditValueSelect() {
 }
 
 void GEM::prevEditValueSelect() {
-  GEMItem* menuItemTmp = _menuPageCurrent->getCurrentMenuItem();
-  GEMSelect* select = menuItemTmp->select;
   if (_valueSelectNum > 0) {
     _valueSelectNum--;
   }
@@ -698,7 +696,6 @@ void GEM::drawEditValueSelect() {
 
 void GEM::saveEditValue() {
   GEMItem* menuItemTmp = _menuPageCurrent->getCurrentMenuItem();
-  void* temp;
   switch (menuItemTmp->linkedType) {
     case GEM_VAL_INTEGER:
       *(int*)menuItemTmp->linkedVariable = atoi(_valueString);

--- a/src/GEM.cpp
+++ b/src/GEM.cpp
@@ -39,7 +39,7 @@
 
 // AVR-based Arduinos have suppoort for dtostrf, some others may require manual inclusion (e.g. SAMD),
 // see https://github.com/plotly/arduino-api/issues/38#issuecomment-108987647
-#if defined(GEM_SUPPORT_FLOAT_EDIT) && (defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_SAM))
+#if defined(GEM_SUPPORT_FLOAT_EDIT) && (defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_SAM) || defined(ARDUINO_ARCH_RP2040))
 #include <avr/dtostrf.h>
 #endif
 

--- a/src/GEMItem.h
+++ b/src/GEMItem.h
@@ -299,11 +299,11 @@ class GEMItem {
     GEMPage* parentPage = nullptr;
     GEMPage* linkedPage = nullptr;
     GEMItem* menuItemNext = nullptr;
-    boolean callbackWithArgs = false;
     union {
       void (*callbackAction)() = nullptr;
       void (*callbackActionArg)(GEMCallbackData);
     };
+    boolean callbackWithArgs = false;
     GEMCallbackData callbackData;
     GEMItem* getMenuItemNext();             // Get next menu item, excluding hidden ones
 };

--- a/src/GEMSelect.cpp
+++ b/src/GEMSelect.cpp
@@ -134,6 +134,9 @@ const char* GEMSelect::getOptionNameByIndex(int index) {
     case GEM_VAL_DOUBLE:
       name = (index > -1 && index < _length) ? optsDouble[index].name : "";
       break;
+    default:
+      name = "";
+      break;
   }
   return name;
 }

--- a/src/GEM_adafruit_gfx.cpp
+++ b/src/GEM_adafruit_gfx.cpp
@@ -39,7 +39,7 @@
 
 // AVR-based Arduinos have suppoort for dtostrf, some others may require manual inclusion (e.g. SAMD),
 // see https://github.com/plotly/arduino-api/issues/38#issuecomment-108987647
-#if defined(GEM_SUPPORT_FLOAT_EDIT) && (defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_SAM) || defined(ARDUINO_ARCH_RP2040))
+#if defined(GEM_SUPPORT_FLOAT_EDIT) && (defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_SAM) || defined(ARDUINO_ARCH_RP2040) || defined(ARDUINO_ARCH_NRF52840))
 #include <avr/dtostrf.h>
 #endif
 

--- a/src/GEM_adafruit_gfx.cpp
+++ b/src/GEM_adafruit_gfx.cpp
@@ -39,7 +39,7 @@
 
 // AVR-based Arduinos have suppoort for dtostrf, some others may require manual inclusion (e.g. SAMD),
 // see https://github.com/plotly/arduino-api/issues/38#issuecomment-108987647
-#if defined(GEM_SUPPORT_FLOAT_EDIT) && (defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_SAM))
+#if defined(GEM_SUPPORT_FLOAT_EDIT) && (defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_SAM) || defined(ARDUINO_ARCH_RP2040))
 #include <avr/dtostrf.h>
 #endif
 

--- a/src/GEM_adafruit_gfx.cpp
+++ b/src/GEM_adafruit_gfx.cpp
@@ -720,8 +720,6 @@ void GEM_adafruit_gfx::nextEditValueSelect() {
 }
 
 void GEM_adafruit_gfx::prevEditValueSelect() {
-  GEMItem* menuItemTmp = _menuPageCurrent->getCurrentMenuItem();
-  GEMSelect* select = menuItemTmp->select;
   if (_valueSelectNum > 0) {
     _valueSelectNum--;
   }
@@ -745,7 +743,6 @@ void GEM_adafruit_gfx::drawEditValueSelect() {
 
 void GEM_adafruit_gfx::saveEditValue() {
   GEMItem* menuItemTmp = _menuPageCurrent->getCurrentMenuItem();
-  void* temp;
   switch (menuItemTmp->linkedType) {
     case GEM_VAL_INTEGER:
       *(int*)menuItemTmp->linkedVariable = atoi(_valueString);

--- a/src/GEM_u8g2.cpp
+++ b/src/GEM_u8g2.cpp
@@ -571,7 +571,6 @@ void GEM_u8g2::enterEditValueMode() {
 
 void GEM_u8g2::checkboxToggle() {
   GEMItem* menuItemTmp = _menuPageCurrent->getCurrentMenuItem();
-  int topOffset = getCurrentItemTopOffset(true, true);
   boolean checkboxValue = *(boolean*)menuItemTmp->linkedVariable;
   *(boolean*)menuItemTmp->linkedVariable = !checkboxValue;
   if (menuItemTmp->callbackAction != nullptr) {
@@ -765,8 +764,6 @@ void GEM_u8g2::nextEditValueSelect() {
 }
 
 void GEM_u8g2::prevEditValueSelect() {
-  GEMItem* menuItemTmp = _menuPageCurrent->getCurrentMenuItem();
-  GEMSelect* select = menuItemTmp->select;
   if (_valueSelectNum > 0) {
     _valueSelectNum--;
   }
@@ -775,7 +772,6 @@ void GEM_u8g2::prevEditValueSelect() {
 
 void GEM_u8g2::saveEditValue() {
   GEMItem* menuItemTmp = _menuPageCurrent->getCurrentMenuItem();
-  void* temp;
   switch (menuItemTmp->linkedType) {
     case GEM_VAL_INTEGER:
       *(int*)menuItemTmp->linkedVariable = atoi(_valueString);

--- a/src/GEM_u8g2.cpp
+++ b/src/GEM_u8g2.cpp
@@ -39,7 +39,7 @@
 
 // AVR-based Arduinos have suppoort for dtostrf, some others may require manual inclusion (e.g. SAMD),
 // see https://github.com/plotly/arduino-api/issues/38#issuecomment-108987647
-#if defined(GEM_SUPPORT_FLOAT_EDIT) && (defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_SAM) || defined(ARDUINO_ARCH_RP2040))
+#if defined(GEM_SUPPORT_FLOAT_EDIT) && (defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_SAM) || defined(ARDUINO_ARCH_RP2040) || defined(ARDUINO_ARCH_NRF52840))
 #include <avr/dtostrf.h>
 #endif
 

--- a/src/GEM_u8g2.cpp
+++ b/src/GEM_u8g2.cpp
@@ -39,7 +39,7 @@
 
 // AVR-based Arduinos have suppoort for dtostrf, some others may require manual inclusion (e.g. SAMD),
 // see https://github.com/plotly/arduino-api/issues/38#issuecomment-108987647
-#if defined(GEM_SUPPORT_FLOAT_EDIT) && (defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_SAM))
+#if defined(GEM_SUPPORT_FLOAT_EDIT) && (defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_SAM) || defined(ARDUINO_ARCH_RP2040))
 #include <avr/dtostrf.h>
 #endif
 


### PR DESCRIPTION
* Explicit inclusion of `avr/dtostrf.h` for RP2040 and nRF52840 based boards (to allow support for floating-point variables);
* `-Wreorder`, `-Wunused-variable`, `-Wmaybe-uninitialized` warnings during compilation for RP2040 and nRF52840 fixes;
* Compatibility section in Readme updated.