### PR TITLE
Chaining support; GEMPage constructor overload

### DIFF
--- a/README.md
+++ b/README.md
@@ -1166,6 +1166,10 @@ Menu page holds menu items `GEMItem` and represents menu level. Menu can have mu
 ```cpp
 GEMPage menuPage(title[, exitAction]);
 ```
+or
+```cpp
+GEMPage menuPage(title[, parentMenuPage]);
+```
 
 * **title**  
   *Type*: `const char*`  
@@ -1175,7 +1179,11 @@ GEMPage menuPage(title[, exitAction]);
 
 * **exitAction** [*optional*]  
   *Type*: `pointer to function`  
-  Pointer to a function that will be executed when `GEM_KEY_CANCEL` key is pressed while being on top level menu page (i.e. page that has no parent menu page) and not in edit mode. Action-specific [context](#appcontext) can be created, which can have its own enter (setup) and exit callbacks as well as loop function.
+  Pointer to a function that will be executed when `GEM_KEY_CANCEL` key is pressed while being on top level menu page (i.e. page that has no parent menu page) and not in edit mode. Action-specific [context](#appcontext) can be created, which can have its own enter (setup) and exit callbacks as well as loop function. Current menu item will be set to the first item of the menu page upon calling this function, this change will be reflected with the subsequent explicit redraw of the menu (e.g. by calling `drawMenu()` method of `GEM`, `GEM_u8g2` or `GEM_adafruit_gfx` object).
+
+* **parentMenuPage** [*optional*]  
+  *Type*: `GEMPage`  
+  Parent level menu page (to know where to go back to when pressing Back button, which will be added automatically). Alternatively can be set by calling `setParentMenuPage()` method (see below).
 
 #### Methods
 
@@ -1187,7 +1195,7 @@ GEMPage menuPage(title[, exitAction]);
 * **setParentMenuPage(** _GEMPage&_ parentMenuPage **)**  
   *Accepts*: `GEMPage`  
   *Returns*: nothing  
-  Specify parent level menu page (to know where to go back to when pressing Back button, that will be added automatically). Accepts `GEMPage` object.
+  Specify parent level menu page (to know where to go back to when pressing Back button, which will be added automatically). Accepts `GEMPage` object.
 
 * **setTitle(** _const char*_ title **)**  
   *Returns*: nothing  

--- a/README.md
+++ b/README.md
@@ -1042,50 +1042,50 @@ For more details on customization see corresponding section of the [wiki](https:
 
 #### Methods
 
-* **setSplash(** _const uint8_t PROGMEM_ *sprite **)**  `AltSerialGraphicLCD version`  
+* *GEM&* **setSplash(** _const uint8_t PROGMEM_ *sprite **)**  `AltSerialGraphicLCD version`  
   *Accepts*: `_const uint8_t PROGMEM_ *`  
-  *Returns*: nothing  
+  *Returns*: `GEM&`  
   Set custom sprite displayed as the splash screen when GEM is being initialized. Should be called before `GEM::init()`. The following is the format of the sprite as described in AltSerialGraphicLCD library documentation:
   > The sprite commences with two bytes which are the width and height of the image in pixels. The pixel data is organised as rows of 8 vertical pixels per byte where the least significant bit (LSB) is the top-left pixel and the most significant bit (MSB) tends towards the bottom-left pixel. A complete row of 8 vertical pixels across the image width comprises the first row, this is then followed by the next row of 8 vertical pixels and so on. Where the image height is not an exact multiple of 8 bits then any unused bits are typically set to zero (although this does not matter).
 
   For more details on splash customization see corresponding section of the [wiki](https://github.com/Spirik/GEM/wiki).
 
-* **setSplash(** _byte_ width, _byte_ height, _const unsigned char U8X8_PROGMEM_ *image **)**  `U8g2 version`  
+* *GEM_u8g2&* **setSplash(** _byte_ width, _byte_ height, _const unsigned char U8X8_PROGMEM_ *image **)**  `U8g2 version`  
   *Accepts*: `byte`, `byte`, `_const unsigned char U8X8_PROGMEM_ *`  
-  *Returns*: nothing  
+  *Returns*: `GEM_u8g2&`  
   Set custom [XBM](https://en.wikipedia.org/wiki/X_BitMap) image displayed as the splash screen when GEM is being initialized. Should be called before `GEM_u8g2::init()`. For more details on splash customization and example refer to corresponding section of the [wiki](https://github.com/Spirik/GEM/wiki).
 
-* **setSplash(** _byte_ width, _byte_ height, _const uint8_t PROGMEM_ *image **)**  `Adafruit GFX version`  
+* *GEM_adafruit_gfx&* **setSplash(** _byte_ width, _byte_ height, _const uint8_t PROGMEM_ *image **)**  `Adafruit GFX version`  
   *Accepts*: `byte`, `byte`, `_const uint8_t PROGMEM_ *`  
-  *Returns*: nothing  
+  *Returns*: `GEM_adafruit_gfx&`  
   Set custom bitmap image displayed as the splash screen when GEM is being initialized. The following is the format of the bitmap as described in Adafruit GFX library documentation:
   > A contiguous block of bits, where each `1` bit sets the corresponding pixel to 'color', while each `0` bit is skipped.
 
   Bitmap must be presented as a byte array and located in program memory using the PROGMEM directive, width and height of the bitmap must be supplied as a first and second argument to the function respectively. Should be called before `GEM_adafruit_gfx::init()`. See [Bitmaps](https://learn.adafruit.com/adafruit-gfx-graphics-library/graphics-primitives#bitmaps-2002806-39) section of Adafruit GFX documentation for more details and [image2cpp](http://javl.github.io/image2cpp/) webtool for online bitmap conversion. For more details on splash customization and example refer to corresponding section of the [wiki](https://github.com/Spirik/GEM/wiki).
 
-* **setSplashDelay(** _uint16_t_ value **)**  
+* *GEM&* **setSplashDelay(** _uint16_t_ value **)**  
   *Accepts*: `uint16_t`  
-  *Returns*: nothing  
+  *Returns*: `GEM&`, or `GEM_u8g2&`, or `GEM_adafruit_gfx&`  
   Set splash screen delay (in ms). By default splash screen will be visible for 1000ms. Maximum supported value is 65535ms. Setting to 0 will disable splash screen. Should be called before `init()`.
   > **Note:** internally splash screen delay is implemented via `delay()` function. This is the only place in library where `delay()` is utilized (aside of example sketches).
 
-* **hideVersion(** _bool_ flag = true **)**  
+* *GEM&* **hideVersion(** _bool_ flag = true **)**  
   *Accepts*: `bool`  
-  *Returns*: nothing  
+  *Returns*: `GEM&`, or `GEM_u8g2&`, or `GEM_adafruit_gfx&`  
   Turn printing of the current GEM library version on splash screen off (`hideVersion()`) or back on (`hideVersion(false)`). By default the version is printed. Should be called before `init()`.
 
-* **enableCyrillic(** _bool_ flag = true **)**  `U8g2 version only`  
+* *GEM_u8g2&* **enableCyrillic(** _bool_ flag = true **)**  `U8g2 version only`  
   *Accepts*: `bool`  
-  *Returns*: nothing  
+  *Returns*: `GEM_u8g2&`  
   Turn Cyrillic typeset on (`enableCyrillic()`) or off (`enableCyrillic(false)`). [`u8g2_font_6x12_t_cyrillic`](https://raw.githubusercontent.com/wiki/olikraus/u8g2/fntpic/u8g2_font_6x12_t_cyrillic.png) and [`u8g2_font_4x6_t_cyrillic`](https://raw.githubusercontent.com/wiki/olikraus/u8g2/fntpic/u8g2_font_4x6_t_cyrillic.png) fonts from [U8g2](https://github.com/olikraus/u8g2/wiki/fntlistall) will be used when Cyrillic typeset is enabled, and default fonts [`u8g2_font_6x12_tr`](https://raw.githubusercontent.com/wiki/olikraus/u8g2/fntpic/u8g2_font_6x12_tr.png) and [`u8g2_font_tom_thumb_4x6_tr`](https://raw.githubusercontent.com/wiki/olikraus/u8g2/fntpic/u8g2_font_tom_thumb_4x6_tr.png) will be used otherwise. You may use Cyrillic in menu title, menu item labels (`GEMItem`, including buttons and menu page links), and select options (`SelectOptionInt`, `SelectOptionByte`, `SelectOptionChar` data structures). Editable strings with Cyrillic characters are **not supported** (edit mode of such strings may lead to unpredictable results due to incompatibility with 2-byte characters). Increases required program storage space, use cautiously. By default Cyrillic typeset is off. Should be called before `GEM_u8g2::init()`.
 
-* **invertKeysDuringEdit(** _bool_ invert = true **)**  
+* *GEM&* **invertKeysDuringEdit(** _bool_ invert = true **)**  
   *Accepts*: `bool`  
-  *Returns*: nothing  
+  *Returns*: `GEM&`, or `GEM_u8g2&`, or `GEM_adafruit_gfx&`  
   Turn inverted order of characters during edit mode on (`invertKeysDuringEdit()`) or off (`invertKeysDuringEdit(false)`). By default when in edit mode of a number or a `char[17]` variable, digits (and other characters) increment when `GEM_KEY_UP` key is pressed and decrement when `GEM_KEY_DOWN` key is pressed. Inverting this order may lead to more natural expected behavior when editing `char[17]` or number variables with certain input devices (e.g. rotary encoder, in which case rotating knob clock-wise is generally associated with `GEM_KEY_DOWN` action during navigation through menu items, but in edit mode it seems more natural to increment a digit rather than to decrement it when performing the same clock-wise rotation).
 
-* **init()**  
-  *Returns*: nothing  
+* *GEM&* **init()**  
+  *Returns*: `GEM&`, or `GEM_u8g2&`, or `GEM_adafruit_gfx&`  
   Init the menu: load necessary sprites into RAM of the SparkFun Graphic LCD Serial Backpack (for AltSerialGraphicLCD version), display GEM splash screen, etc.
   > The following `GLCD` object settings will be applied during `init()`: 
   > * `glcd.drawMode(GLCD_MODE_NORMAL)`;
@@ -1108,46 +1108,48 @@ For more details on customization see corresponding section of the [wiki](https:
   > 
   > Keep this in mind if you are planning to use the same object in your own routines.
 
-* **reInit()**  
-  *Returns*: nothing  
+* *GEM&* **reInit()**  
+  **Returns*: `GEM&`, or `GEM_u8g2&`, or `GEM_adafruit_gfx&`  
   Set GEM specific settings to their values, set initially in `init()` method. If you were working with AltSerialGraphicLCD, U8g2 or Adafruit GFX graphics in your own user-defined button action, it may be a good idea to call `reInit()` before drawing menu back to screen (generally in custom `context.exit()` routine). See [context](#appcontext) for more details.
 
-* **setTextSize(** _uint8_t_ size **)**  `Adafruit GFX version only`  
+* *GEM_adafruit_gfx&* **setTextSize(** _uint8_t_ size **)**  `Adafruit GFX version only`  
   *Accepts*: `uint8_t`  
-  *Returns*: nothing  
+  *Returns*: `GEM_adafruit_gfx&`  
   Set text 'magnification' size (as per Adafruit GFX docs) to supplied value. See Adafruit GFX [documentation](http://adafruit.github.io/Adafruit-GFX-Library/html/class_adafruit___g_f_x.html#a39eb4a8a2c9fa4ab7d58ceffd19535d5) for details on internaly called method of the same name. Sprites (i.e. various menu icons) will be scaled maximum up to two times regardless of the value. If not called explicitly, magnification size will be set to 1. Should be called before `init()`.
 
-* **setForegroundColor(** _uint16_t_ color **)**  `Adafruit GFX version only`  
+* *GEM_adafruit_gfx&* **setForegroundColor(** _uint16_t_ color **)**  `Adafruit GFX version only`  
   *Accepts*: `uint16_t`  
-  *Returns*: nothing  
+  *Returns*: `GEM_adafruit_gfx&`  
   Set foreground color to supplied value. Accepts 16-bit RGB color representation. See Adafruit GFX [documentation](https://learn.adafruit.com/adafruit-gfx-graphics-library/coordinate-system-and-units) for detailed description of a format. Will take effect next time menu is drawn. If not called explicitly, foreground color will be set to 0xFFFF. For more details on color customization and example refer to corresponding section of the [wiki](https://github.com/Spirik/GEM/wiki).
 
-* **setBackgroundColor(** _uint16_t_ color **)**  `Adafruit GFX version only`  
+* *GEM_adafruit_gfx&* **setBackgroundColor(** _uint16_t_ color **)**  `Adafruit GFX version only`  
   *Accepts*: `uint16_t`  
-  *Returns*: nothing  
+  *Returns*: `GEM_adafruit_gfx&`  
   Set background color to supplied value. Accepts 16-bit RGB color representation. See Adafruit GFX [documentation](https://learn.adafruit.com/adafruit-gfx-graphics-library/coordinate-system-and-units) for detailed description of a format. Will take effect next time menu is drawn. If not called explicitly, background color will be set to 0x0000. For more details on color customization and example refer to corresponding section of the [wiki](https://github.com/Spirik/GEM/wiki).
 
-* **setMenuPageCurrent(** _GEMPage&_ menuPageCurrent **)**  
+* *GEM&* **setMenuPageCurrent(** _GEMPage&_ menuPageCurrent **)**  
   *Accepts*: `GEMPage`  
-  *Returns*: nothing  
+  *Returns*: `GEM&`, or `GEM_u8g2&`, or `GEM_adafruit_gfx&`  
   Set supplied menu page as current. Accepts `GEMPage` object.
 
-* **drawMenu()**  
-  *Returns*: nothing  
+* *GEM&* **drawMenu()**  
+  *Returns*: `GEM&`, or `GEM_u8g2&`, or `GEM_adafruit_gfx&`  
   Draw menu on screen, with menu page set earlier in `setMenuPageCurrent()`.
 
 * *bool* **readyForKey()**  
   *Returns*: `bool`  
   Check that menu is waiting for the key press.
 
-* **registerKeyPress(** _byte_ keyCode **)**  
+* *GEM&* **registerKeyPress(** _byte_ keyCode **)**  
   *Accepts*: `byte` (*Values*: `GEM_KEY_NONE`, `GEM_KEY_UP`, `GEM_KEY_RIGHT`, `GEM_KEY_DOWN`, `GEM_KEY_LEFT`, `GEM_KEY_CANCEL`, `GEM_KEY_OK`)  
-  *Returns*: nothing  
+  *Returns*: `GEM&`, or `GEM_u8g2&`, or `GEM_adafruit_gfx&`  
   Register the key press and trigger corresponding action (navigation through the menu, editing values, pressing menu buttons).
 
-* **clearContext()**  
-  *Returns*: nothing  
+* *GEM&* **clearContext()**  
+  *Returns*: `GEM&`, or `GEM_u8g2&`, or `GEM_adafruit_gfx&`  
   Clear context. Assigns `nullptr` values to function pointers of the `context` property and sets `allowExit` flag of the `context` to `true`.
+
+> **Note:** calls to methods that return a reference to the owning `GEM`, or `GEM_u8g2`, or `GEM_adafruit_gfx` object can be chained, e.g. `menu.hideVersion().invertKeysDuringEdit().init();` (since GEM ver. 1.4.6).
 
 #### Properties
 
@@ -1183,27 +1185,29 @@ GEMPage menuPage(title[, parentMenuPage]);
 
 * **parentMenuPage** [*optional*]  
   *Type*: `GEMPage`  
-  Parent level menu page (to know where to go back to when pressing Back button, which will be added automatically). Alternatively can be set by calling `setParentMenuPage()` method (see below).
+  Parent level menu page (to know where to go back to when pressing Back button, which will be added automatically). Alternatively can be set by calling `GEMPage::setParentMenuPage()` method (see below).
 
 #### Methods
 
-* **addMenuItem(** _GEMItem&_ menuItem **)**  
+* *GEMPage&* **addMenuItem(** _GEMItem&_ menuItem **)**  
   *Accepts*: `GEMItem`  
-  *Returns*: nothing  
+  *Returns*: `GEMPage&`  
   Add menu item to menu page. Accepts `GEMItem` object.
 
-* **setParentMenuPage(** _GEMPage&_ parentMenuPage **)**  
+* *GEMPage&* **setParentMenuPage(** _GEMPage&_ parentMenuPage **)**  
   *Accepts*: `GEMPage`  
-  *Returns*: nothing  
+  *Returns*: `GEMPage&`  
   Specify parent level menu page (to know where to go back to when pressing Back button, which will be added automatically). Accepts `GEMPage` object.
 
-* **setTitle(** _const char*_ title **)**  
-  *Returns*: nothing  
+* *GEMPage&* **setTitle(** _const char*_ title **)**  
+  *Returns*: `GEMPage&`  
   Set title of the menu page. Can be used to update menu page title dynamically.
 
 * *const char** **getTitle()**  
   *Returns*: `const char*`  
   Get title of the menu page.
+
+> **Note:** calls to methods that return a reference to the owning `GEMPage` object can be chained, e.g. `menuPageSettings.addMenuItem(menuItemInterval).addMenuItem(menuItemTempo).setParentMenuPage(menuPageMain);` (since GEM ver. 1.4.6).
 
 
 ----------
@@ -1359,42 +1363,43 @@ GEMItem menuItemButton(title, buttonAction[, callbackVal[, readonly]]);
 
 #### Methods
 
-* **setCallbackVal(** _int_ | _byte_ | _float_ | _double_ | _bool_ | _const char*_ | _void*_ callbackVal **)**  
-  *Returns*: nothing  
+* *GEMItem&* **setCallbackVal(** _int_ | _byte_ | _float_ | _double_ | _bool_ | _const char*_ | _void*_ callbackVal **)**  
+  *Returns*: `GEMItem&`  
   Set user-defined value of an argument that will be passed to callback function as a part of [`GEMCallbackData`](#gemcallbackdata) struct.
 
 * *GEMCallbackData* **getCallbackData()**  
   *Returns*: `GEMCallbackData`  
   Get [`GEMCallbackData`](#gemcallbackdata) struct associated with menu item. It contains pointer to menu item and optionally user-defined value.
 
-* **setTitle(** _const char*_ title **)**  
-  *Returns*: nothing  
+* *GEMItem&* **setTitle(** _const char*_ title **)**  
+  *Returns*: `GEMItem&`  
   Set title of the menu item. Can be used to update menu item title dynamically.
 
 * *const char** **getTitle()**  
   *Returns*: `const char*`  
   Get title of the menu item.
 
-* **setPrecision()**  
-  *Returns*: nothing  
+* *GEMItem&* **setPrecision(** _byte_ prec **)**  
+  *Accepts*: `byte`  
+  *Returns*: `GEMItem&`  
   Explicitly set precision for `float` or `double` variable as required by [`dtostrf()`](http://www.nongnu.org/avr-libc/user-manual/group__avr__stdlib.html#ga060c998e77fb5fc0d3168b3ce8771d42) conversion used internally, i.e. the number of digits **after** the decimal sign.
 
-* **setReadonly(** _bool_ mode = true **)**  
+* *GEMItem&* **setReadonly(** _bool_ mode = true **)**  
   *Accepts*: `bool`  
-  *Returns*: nothing  
+  *Returns*: `GEMItem&`  
   Explicitly set (`setReadonly(true)`, or `setReadonly(GEM_READONLY)`, or `setReadonly()`) or unset (`setReadonly(false)`) readonly mode for variable that menu item is associated with (relevant for `int`, `byte`, `float`, `double`, `char[17]`, `bool` variable menu items and option select), or menu button and menu link, pressing of which won't result in any action, associated with them.
 
 * *bool* **getReadonly()**  
   *Returns*: `bool`  
   Get readonly state of the variable that menu item is associated with (as well as menu link or button): `true` for readonly state, `false` otherwise.
 
-* **hide(** _bool_ hide = true **)**  
+* *GEMItem&* **hide(** _bool_ hide = true **)**  
   *Accepts*: `bool`  
-  *Returns*: nothing  
+  *Returns*: `GEMItem&`  
   Hide (`hide(true)`, or `hide(GEM_HIDDEN)`, or `hide()`) or show (`hide(false)`) menu item. Hidden menu items won't be printed to the screen the next time menu is drawn.
 
-* **show()**  
-  *Returns*: nothing  
+* *GEMItem&* **show()**  
+  *Returns*: `GEMItem&`  
   Show previously hidden menu item.
 
 * *bool* **getHidden()**  
@@ -1404,6 +1409,8 @@ GEMItem menuItemButton(title, buttonAction[, callbackVal[, readonly]]);
 * *void** **getLinkedVariablePointer()**  
   *Returns*: `void*`  
   Get pointer to a linked variable (relevant for menu items that represent variable). Note that user is reponsible for casting `void*` pointer to a correct pointer type.
+
+> **Note:** calls to methods that return a reference to the owning `GEMItem` object can be chained, e.g. `menuItemInterval.setReadonly().show();` (since GEM ver. 1.4.6).
 
 
 ----------

--- a/src/GEM.cpp
+++ b/src/GEM.cpp
@@ -122,23 +122,27 @@ GEM::GEM(GLCD& glcd_, byte menuPointerType_, byte menuItemsPerScreen_, byte menu
 
 //====================== INIT OPERATIONS
 
-void GEM::setSplash(const uint8_t *sprite) {
+GEM& GEM::setSplash(const uint8_t *sprite) {
   _splash = sprite;
+  return *this;
 }
 
-void GEM::setSplashDelay(uint16_t value) {
+GEM& GEM::setSplashDelay(uint16_t value) {
   _splashDelay = value;
+  return *this;
 }
 
-void GEM::hideVersion(bool flag) {
+GEM& GEM::hideVersion(bool flag) {
   _enableVersion = !flag;
+  return *this;
 }
 
-void GEM::invertKeysDuringEdit(bool invert) {
+GEM& GEM::invertKeysDuringEdit(bool invert) {
   _invertKeysDuringEdit = invert;
+  return *this;
 }
 
-void GEM::init() {
+GEM& GEM::init() {
   _glcd.loadSprite_P(GEM_SPR_ARROW_RIGHT, arrowRight);
   _glcd.loadSprite_P(GEM_SPR_ARROW_LEFT, arrowLeft);
   _glcd.loadSprite_P(GEM_SPR_ARROW_BTN, arrowBtn);
@@ -179,37 +183,43 @@ void GEM::init() {
     }
 
   }
+
+  return *this;
 }
 
-void GEM::reInit() {
+GEM& GEM::reInit() {
   _glcd.drawMode(GLCD_MODE_NORMAL);
   _glcd.fontMode(GLCD_MODE_NORMAL);
   _glcd.set(GLCD_ID_CRLF, 0);
   _glcd.set(GLCD_ID_SCROLL, 0);
   _glcd.clearScreen();
+  return *this;
 }
 
-void GEM::setMenuPageCurrent(GEMPage& menuPageCurrent) {
+GEM& GEM::setMenuPageCurrent(GEMPage& menuPageCurrent) {
   _menuPageCurrent = &menuPageCurrent;
+  return *this;
 }
 
 //====================== CONTEXT OPERATIONS
 
-void GEM::clearContext() {
+GEM& GEM::clearContext() {
   context.loop = nullptr;
   context.enter = nullptr;
   context.exit = nullptr;
   context.allowExit = true;
+  return *this;
 }
 
 //====================== DRAW OPERATIONS
 
-void GEM::drawMenu() {
+GEM& GEM::drawMenu() {
   _glcd.clearScreen();
   drawTitleBar();
   printMenuItems();
   drawMenuPointer();
   drawScrollbar();
+  return *this;
 }
 
 void GEM::drawTitleBar() {
@@ -781,9 +791,10 @@ bool GEM::readyForKey() {
 
 }
 
-void GEM::registerKeyPress(byte keyCode) {
+GEM& GEM::registerKeyPress(byte keyCode) {
   _currentKey = keyCode;
   dispatchKeyPress();
+  return *this;
 }
 
 void GEM::dispatchKeyPress() {

--- a/src/GEM.h
+++ b/src/GEM.h
@@ -97,35 +97,35 @@ class GEM {
 
     /* INIT OPERATIONS */
 
-    void setSplash(const uint8_t *sprite);               // Set custom sprite displayed as the splash screen when GEM is being initialized. Should be called before GEM::init().
-                                                         // The following is the format of the sprite as described in AltSerialGraphicLCD library documentation.
-                                                         // The sprite commences with two bytes which are the width and height of the image in pixels.
-                                                         // The pixel data is organised as rows of 8 vertical pixels per byte where the least significant bit (LSB)
-                                                         // is the top-left pixel and the most significant bit (MSB) tends towards the bottom-left pixel.
-                                                         // A complete row of 8 vertical pixels across the image width comprises the first row, this is then followed
-                                                         // by the next row of 8 vertical pixels and so on.
-                                                         // Where the image height is not an exact multiple of 8 bits then any unused bits are typically set to zero
-                                                         // (although this does not matter).
-    void setSplashDelay(uint16_t value);                 // Set splash screen delay. Default value 1000ms, max value 65535ms. Setting to 0 will disable splash screen. Should be called before GEM::init().
-    void hideVersion(bool flag = true);                  // Turn printing of the current GEM library version on splash screen off or back on. Should be called before GEM::init().
-    void invertKeysDuringEdit(bool invert = true);    // Turn inverted order of characters during edit mode on or off
-    void init();                                         // Init the menu (load necessary sprites into RAM of the SparkFun Graphic LCD Serial Backpack, display GEM splash screen, etc.)
-    void reInit();                                       // Reinitialize the menu (apply GEM specific settings to AltSerialGraphicLCD library)
-    void setMenuPageCurrent(GEMPage& menuPageCurrent);   // Set supplied menu page as current
+    GEM& setSplash(const uint8_t *sprite);              // Set custom sprite displayed as the splash screen when GEM is being initialized. Should be called before GEM::init().
+                                                        // The following is the format of the sprite as described in AltSerialGraphicLCD library documentation.
+                                                        // The sprite commences with two bytes which are the width and height of the image in pixels.
+                                                        // The pixel data is organised as rows of 8 vertical pixels per byte where the least significant bit (LSB)
+                                                        // is the top-left pixel and the most significant bit (MSB) tends towards the bottom-left pixel.
+                                                        // A complete row of 8 vertical pixels across the image width comprises the first row, this is then followed
+                                                        // by the next row of 8 vertical pixels and so on.
+                                                        // Where the image height is not an exact multiple of 8 bits then any unused bits are typically set to zero
+                                                        // (although this does not matter).
+    GEM& setSplashDelay(uint16_t value);                // Set splash screen delay. Default value 1000ms, max value 65535ms. Setting to 0 will disable splash screen. Should be called before GEM::init().
+    GEM& hideVersion(bool flag = true);                 // Turn printing of the current GEM library version on splash screen off or back on. Should be called before GEM::init().
+    GEM& invertKeysDuringEdit(bool invert = true);      // Turn inverted order of characters during edit mode on or off
+    GEM& init();                                        // Init the menu (load necessary sprites into RAM of the SparkFun Graphic LCD Serial Backpack, display GEM splash screen, etc.)
+    GEM& reInit();                                      // Reinitialize the menu (apply GEM specific settings to AltSerialGraphicLCD library)
+    GEM& setMenuPageCurrent(GEMPage& menuPageCurrent);  // Set supplied menu page as current
 
     /* CONTEXT OPERATIONS */
 
     AppContext context;                                  // Currently set context
-    void clearContext();                                 // Clear context
+    GEM& clearContext();                                 // Clear context
 
     /* DRAW OPERATIONS */
 
-    void drawMenu();                                     // Draw menu on screen, with menu page set earlier in GEM::setMenuPageCurrent()
+    GEM& drawMenu();                                     // Draw menu on screen, with menu page set earlier in GEM::setMenuPageCurrent()
 
     /* KEY DETECTION */
 
     bool readyForKey();                                  // Check that menu is waiting for the key press
-    void registerKeyPress(byte keyCode);                 // Register the key press and trigger corresponding action
+    GEM& registerKeyPress(byte keyCode);                 // Register the key press and trigger corresponding action
                                                          // Accepts GEM_KEY_NONE, GEM_KEY_UP, GEM_KEY_RIGHT, GEM_KEY_DOWN, GEM_KEY_LEFT, GEM_KEY_CANCEL, GEM_KEY_OK values
   private:
     GLCD& _glcd;

--- a/src/GEMItem.cpp
+++ b/src/GEMItem.cpp
@@ -1272,32 +1272,39 @@ GEMItem::GEMItem(const char* title_, void (*callbackAction_)(GEMCallbackData), v
 
 //---
 
-void GEMItem::setCallbackVal(byte callbackVal_) {
+GEMItem& GEMItem::setCallbackVal(byte callbackVal_) {
   callbackData.valByte = callbackVal_;
+  return *this;
 }
 
-void GEMItem::setCallbackVal(int callbackVal_) {
+GEMItem& GEMItem::setCallbackVal(int callbackVal_) {
   callbackData.valInt = callbackVal_;
+  return *this;
 }
 
-void GEMItem::setCallbackVal(float callbackVal_) {
+GEMItem& GEMItem::setCallbackVal(float callbackVal_) {
   callbackData.valFloat = callbackVal_;
+  return *this;
 }
 
-void GEMItem::setCallbackVal(double callbackVal_) {
+GEMItem& GEMItem::setCallbackVal(double callbackVal_) {
   callbackData.valDouble = callbackVal_;
+  return *this;
 }
 
-void GEMItem::setCallbackVal(bool callbackVal_) {
+GEMItem& GEMItem::setCallbackVal(bool callbackVal_) {
   callbackData.valBool = callbackVal_;
+  return *this;
 }
 
-void GEMItem::setCallbackVal(const char* callbackVal_) {
+GEMItem& GEMItem::setCallbackVal(const char* callbackVal_) {
   callbackData.valChar = callbackVal_;
+  return *this;
 }
 
-void GEMItem::setCallbackVal(void* callbackVal_) {
+GEMItem& GEMItem::setCallbackVal(void* callbackVal_) {
   callbackData.valPointer = callbackVal_;
+  return *this;
 }
 
 GEMCallbackData GEMItem::getCallbackData() {
@@ -1306,27 +1313,30 @@ GEMCallbackData GEMItem::getCallbackData() {
 
 //---
 
-void GEMItem::setTitle(const char* title_) {
+GEMItem& GEMItem::setTitle(const char* title_) {
   title = title_;
+  return *this;
 }
 
 const char* GEMItem::getTitle() {
   return title;
 }
 
-void GEMItem::setPrecision(byte prec) {
+GEMItem& GEMItem::setPrecision(byte prec) {
   precision = prec;
+  return *this;
 }
 
-void GEMItem::setReadonly(bool mode) {
+GEMItem& GEMItem::setReadonly(bool mode) {
   readonly = mode;
+  return *this;
 }
 
 bool GEMItem::getReadonly() {
   return readonly;
 }
 
-void GEMItem::hide(bool hide) {
+GEMItem& GEMItem::hide(bool hide) {
   if (hide) {
     if (!hidden) {
       if (parentPage != nullptr) {
@@ -1338,9 +1348,10 @@ void GEMItem::hide(bool hide) {
   } else {
     show();
   }
+  return *this;
 }
 
-void GEMItem::show() {
+GEMItem& GEMItem::show() {
   if (hidden) {
     if (parentPage != nullptr) {
       parentPage->showMenuItem(*this);
@@ -1348,6 +1359,7 @@ void GEMItem::show() {
       hidden = false;
     }
   }
+  return *this;
 }
 
 bool GEMItem::getHidden() {

--- a/src/GEMItem.h
+++ b/src/GEMItem.h
@@ -266,27 +266,27 @@ class GEMItem {
     GEMItem(const char* title_, void (*callbackAction_)(GEMCallbackData), const char* callbackVal_, bool readonly_ = false);
     GEMItem(const char* title_, void (*callbackAction_)(GEMCallbackData), void* callbackVal_, bool readonly_ = false);
 
-    void setCallbackVal(byte callbackVal_); // Set value of an argument that will be passed to callback within GEMCallbackData (either byte, int, bool, float, double, char or void pointer)
-    void setCallbackVal(int callbackVal_);
-    void setCallbackVal(float callbackVal_);
-    void setCallbackVal(double callbackVal_);
-    void setCallbackVal(bool callbackVal_);
-    void setCallbackVal(const char* callbackVal_);
-    void setCallbackVal(void* callbackVal_);
-    GEMCallbackData getCallbackData();      // Get GEMCallbackData struct associated with menu item
-    void setTitle(const char* title_);      // Set title of the menu item
-    const char* getTitle();                 // Get title of the menu item
-    void setPrecision(byte prec);           // Explicitly set precision for float or double variables as required by dtostrf() conversion,
-                                            // i.e. the number of digits after the decimal sign
-    void setReadonly(bool mode = true);     // Explicitly set or unset readonly mode for variable that menu item is associated with
-                                            // (relevant for GEM_VAL_INTEGER, GEM_VAL_BYTE, GEM_VAL_FLOAT, GEM_VAL_DOUBLE, GEM_VAL_CHAR,
-                                            // GEM_VAL_BOOL variable menu items and GEM_VAL_SELECT option select), or menu button GEM_ITEM_BUTTON
-                                            // and menu link GEM_ITEM_LINK, pressing of which won't result in any action, associated with them
-    bool getReadonly();                     // Get readonly state of the variable that menu item is associated with (as well as menu link or button)
-    void hide(bool hide = true);            // Explicitly hide or show menu item
-    void show();                            // Explicitly show menu item
-    bool getHidden();                       // Get hidden state of the menu item
-    void* getLinkedVariablePointer();       // Get pointer to a linked variable (relevant for menu items that represent variable)
+    GEMItem& setCallbackVal(byte callbackVal_); // Set value of an argument that will be passed to callback within GEMCallbackData (either byte, int, bool, float, double, char or void pointer)
+    GEMItem& setCallbackVal(int callbackVal_);
+    GEMItem& setCallbackVal(float callbackVal_);
+    GEMItem& setCallbackVal(double callbackVal_);
+    GEMItem& setCallbackVal(bool callbackVal_);
+    GEMItem& setCallbackVal(const char* callbackVal_);
+    GEMItem& setCallbackVal(void* callbackVal_);
+    GEMCallbackData getCallbackData();          // Get GEMCallbackData struct associated with menu item
+    GEMItem& setTitle(const char* title_);      // Set title of the menu item
+    const char* getTitle();                     // Get title of the menu item
+    GEMItem& setPrecision(byte prec);           // Explicitly set precision for float or double variables as required by dtostrf() conversion,
+                                                // i.e. the number of digits after the decimal sign
+    GEMItem& setReadonly(bool mode = true);     // Explicitly set or unset readonly mode for variable that menu item is associated with
+                                                // (relevant for GEM_VAL_INTEGER, GEM_VAL_BYTE, GEM_VAL_FLOAT, GEM_VAL_DOUBLE, GEM_VAL_CHAR,
+                                                // GEM_VAL_BOOL variable menu items and GEM_VAL_SELECT option select), or menu button GEM_ITEM_BUTTON
+                                                // and menu link GEM_ITEM_LINK, pressing of which won't result in any action, associated with them
+    bool getReadonly();                         // Get readonly state of the variable that menu item is associated with (as well as menu link or button)
+    GEMItem& hide(bool hide = true);            // Explicitly hide or show menu item
+    GEMItem& show();                            // Explicitly show menu item
+    bool getHidden();                           // Get hidden state of the menu item
+    void* getLinkedVariablePointer();           // Get pointer to a linked variable (relevant for menu items that represent variable)
   private:
     const char* title;
     void* linkedVariable = nullptr;

--- a/src/GEMPage.cpp
+++ b/src/GEMPage.cpp
@@ -42,7 +42,7 @@ GEMPage::GEMPage(const char* title_, void (*exitAction_)())
   , exitAction(exitAction_)
 { }
 
-void GEMPage::addMenuItem(GEMItem& menuItem) {
+GEMPage& GEMPage::addMenuItem(GEMItem& menuItem) {
   // Prevent adding menu item that was already added to another (or the same) page
   if (menuItem.parentPage == nullptr) {
     if (itemsCountTotal == 0) {
@@ -59,9 +59,10 @@ void GEMPage::addMenuItem(GEMItem& menuItem) {
     itemsCountTotal++;
     currentItemNum = (_menuItemBack.linkedPage != nullptr) ? 1 : 0;
   }
+  return *this;
 }
 
-void GEMPage::setParentMenuPage(GEMPage& parentMenuPage) {
+GEMPage& GEMPage::setParentMenuPage(GEMPage& parentMenuPage) {
   _menuItemBack.type = GEM_ITEM_BACK;
   _menuItemBack.linkedPage = &parentMenuPage;
   // Back button menu item should be always inserted at first position in list
@@ -73,10 +74,12 @@ void GEMPage::setParentMenuPage(GEMPage& parentMenuPage) {
   itemsCount++;
   itemsCountTotal++;
   currentItemNum = (itemsCount > 1) ? 1 : 0;
+  return *this;
 }
 
-void GEMPage::setTitle(const char* title_) {
+GEMPage& GEMPage::setTitle(const char* title_) {
   title = title_;
+  return *this;
 }
 
 const char* GEMPage::getTitle() {

--- a/src/GEMPage.cpp
+++ b/src/GEMPage.cpp
@@ -37,10 +37,20 @@
 #include <Arduino.h>
 #include "GEMPage.h"
 
+GEMPage::GEMPage(const char* title_)
+  : title(title_)
+{ }
+
 GEMPage::GEMPage(const char* title_, void (*exitAction_)())
   : title(title_)
   , exitAction(exitAction_)
 { }
+
+GEMPage::GEMPage(const char* title_, GEMPage& parentMenuPage_)
+  : title(title_)
+{
+  setParentMenuPage(parentMenuPage_);
+}
 
 GEMPage& GEMPage::addMenuItem(GEMItem& menuItem) {
   // Prevent adding menu item that was already added to another (or the same) page

--- a/src/GEMPage.h
+++ b/src/GEMPage.h
@@ -52,10 +52,10 @@ class GEMPage {
       @param 'exitAction_' - pointer to callback function executed when GEM_KEY_CANCEL is pressed while being on top level menu page
     */
     GEMPage(const char* title_ = "", void (*exitAction_)() = nullptr);
-    void addMenuItem(GEMItem& menuItem);              // Add menu item to menu page
-    void setParentMenuPage(GEMPage& parentMenuPage);  // Specify parent level menu page (to know where to go back to when pressing Back button)
-    void setTitle(const char* title_);                // Set title of the menu page
-    const char* getTitle();                           // Get title of the menu page
+    GEMPage& addMenuItem(GEMItem& menuItem);              // Add menu item to menu page
+    GEMPage& setParentMenuPage(GEMPage& parentMenuPage);  // Specify parent level menu page (to know where to go back to when pressing Back button)
+    GEMPage& setTitle(const char* title_);                // Set title of the menu page
+    const char* getTitle();                               // Get title of the menu page
   private:
     const char* title;
     byte currentItemNum = 0;                          // Currently selected (focused) menu item of the page

--- a/src/GEMPage.h
+++ b/src/GEMPage.h
@@ -50,10 +50,13 @@ class GEMPage {
     /* 
       @param 'title_' - title of the menu page displayed at top of the screen
       @param 'exitAction_' - pointer to callback function executed when GEM_KEY_CANCEL is pressed while being on top level menu page
+      @param 'parentMenuPage_' - reference to parent level menu page (to know where to go back to when Back button is pressed)
     */
-    GEMPage(const char* title_ = "", void (*exitAction_)() = nullptr);
+    GEMPage(const char* title_);
+    GEMPage(const char* title_, void (*exitAction_)());
+    GEMPage(const char* title_, GEMPage& parentMenuPage_);
     GEMPage& addMenuItem(GEMItem& menuItem);              // Add menu item to menu page
-    GEMPage& setParentMenuPage(GEMPage& parentMenuPage);  // Specify parent level menu page (to know where to go back to when pressing Back button)
+    GEMPage& setParentMenuPage(GEMPage& parentMenuPage);  // Specify parent level menu page (to know where to go back to when Back button is pressed)
     GEMPage& setTitle(const char* title_);                // Set title of the menu page
     const char* getTitle();                               // Get title of the menu page
   private:

--- a/src/GEM_adafruit_gfx.cpp
+++ b/src/GEM_adafruit_gfx.cpp
@@ -221,40 +221,47 @@ GEM_adafruit_gfx::GEM_adafruit_gfx(Adafruit_GFX& agfx_, byte menuPointerType_, b
 
 //====================== INIT OPERATIONS
 
-void GEM_adafruit_gfx::setSplash(byte width, byte height, const uint8_t *image) {
+GEM_adafruit_gfx& GEM_adafruit_gfx::setSplash(byte width, byte height, const uint8_t *image) {
   _splash = {width, height, image};
+  return *this;
 }
 
-void GEM_adafruit_gfx::setSplashDelay(uint16_t value) {
+GEM_adafruit_gfx& GEM_adafruit_gfx::setSplashDelay(uint16_t value) {
   _splashDelay = value;
+  return *this;
 }
 
-void GEM_adafruit_gfx::hideVersion(bool flag) {
+GEM_adafruit_gfx& GEM_adafruit_gfx::hideVersion(bool flag) {
   _enableVersion = !flag;
+  return *this;
 }
 
-void GEM_adafruit_gfx::setTextSize(uint8_t size) {
+GEM_adafruit_gfx& GEM_adafruit_gfx::setTextSize(uint8_t size) {
   _textSize = size > 0 ? size : 1;
   _menuItemFontSize = _menuItemHeight >= 8 * _textSize ? 0 : 1;
   _menuItemInsetOffset = (_menuItemHeight - _menuItemFont[_menuItemFontSize].height * _textSize) / 2;
   if (_splash.image == logo[0].image || _splash.image == logo[1].image) {
     _splash = logo[_textSize > 1 ? 1 : 0];
   }
+  return *this;
 }
 
-void GEM_adafruit_gfx::setForegroundColor(uint16_t color) {
+GEM_adafruit_gfx& GEM_adafruit_gfx::setForegroundColor(uint16_t color) {
   _menuForegroundColor = color;
+  return *this;
 }
 
-void GEM_adafruit_gfx::setBackgroundColor(uint16_t color) {
+GEM_adafruit_gfx& GEM_adafruit_gfx::setBackgroundColor(uint16_t color) {
   _menuBackgroundColor = color;
+  return *this;
 }
 
-void GEM_adafruit_gfx::invertKeysDuringEdit(bool invert) {
+GEM_adafruit_gfx& GEM_adafruit_gfx::invertKeysDuringEdit(bool invert) {
   _invertKeysDuringEdit = invert;
+  return *this;
 }
 
-void GEM_adafruit_gfx::init() {
+GEM_adafruit_gfx& GEM_adafruit_gfx::init() {
   _agfx.setTextSize(_textSize);
   _agfx.setTextWrap(false);
   _agfx.setTextColor(_menuForegroundColor);
@@ -290,36 +297,42 @@ void GEM_adafruit_gfx::init() {
     _agfx.fillScreen(_menuBackgroundColor);
 
   }
+
+  return *this;
 }
 
-void GEM_adafruit_gfx::reInit() {
+GEM_adafruit_gfx& GEM_adafruit_gfx::reInit() {
   _agfx.setTextSize(_textSize);
   _agfx.setTextWrap(false);
   _agfx.setTextColor(_menuForegroundColor);
   _agfx.fillScreen(_menuBackgroundColor);
+  return *this;
 }
 
-void GEM_adafruit_gfx::setMenuPageCurrent(GEMPage& menuPageCurrent) {
+GEM_adafruit_gfx& GEM_adafruit_gfx::setMenuPageCurrent(GEMPage& menuPageCurrent) {
   _menuPageCurrent = &menuPageCurrent;
+  return *this;
 }
 
 //====================== CONTEXT OPERATIONS
 
-void GEM_adafruit_gfx::clearContext() {
+GEM_adafruit_gfx& GEM_adafruit_gfx::clearContext() {
   context.loop = nullptr;
   context.enter = nullptr;
   context.exit = nullptr;
   context.allowExit = true;
+  return *this;
 }
 
 //====================== DRAW OPERATIONS
 
-void GEM_adafruit_gfx::drawMenu() {
+GEM_adafruit_gfx& GEM_adafruit_gfx::drawMenu() {
   _agfx.fillScreen(_menuBackgroundColor);
   drawTitleBar();
   printMenuItems();
   drawMenuPointer();
   drawScrollbar();
+  return *this;
 }
 
 void GEM_adafruit_gfx::drawTitleBar() {
@@ -949,9 +962,10 @@ bool GEM_adafruit_gfx::readyForKey() {
 
 }
 
-void GEM_adafruit_gfx::registerKeyPress(byte keyCode) {
+GEM_adafruit_gfx& GEM_adafruit_gfx::registerKeyPress(byte keyCode) {
   _currentKey = keyCode;
   dispatchKeyPress();
+  return *this;
 }
 
 void GEM_adafruit_gfx::dispatchKeyPress() {

--- a/src/GEM_adafruit_gfx.h
+++ b/src/GEM_adafruit_gfx.h
@@ -117,33 +117,33 @@ class GEM_adafruit_gfx {
 
     /* INIT OPERATIONS */
 
-    void setSplash(byte width, byte height, const uint8_t *image);  // Set custom bitmap image displayed as the splash screen when GEM is being initialized. Should be called before GEM_adafruit_gfx::init().
-                                                                    // The following is the format of the bitmap as described in Adafruit GFX library documentation.
-                                                                    // A contiguous block of bits, where each '1' bit sets the corresponding pixel to 'color,' while each '0' bit is skipped.
-    void setSplashDelay(uint16_t value);                 // Set splash screen delay. Default value 1000ms, max value 65535ms. Setting to 0 will disable splash screen. Should be called before GEM::init().
-    void hideVersion(bool flag = true);                  // Turn printing of the current GEM library version on splash screen off or back on. Should be called before GEM::init().
-    void setTextSize(uint8_t size);                      // Set text 'magnification' size (as per Adafruit GFX docs); sprites will be scaled maximum up to two times regardless of the supplied value (default is 1)
-    void setForegroundColor(uint16_t color);             // Set foreground color of the menu (default is 0xFF)
-    void setBackgroundColor(uint16_t color);             // Set background color of the menu (default is 0x00)
-    void invertKeysDuringEdit(bool invert = true);       // Turn inverted order of characters during edit mode on or off
-    void init();                                         // Init the menu (load necessary sprites into RAM of the SparkFun Graphic LCD Serial Backpack, display GEM splash screen, etc.)
-    void reInit();                                       // Reinitialize the menu (apply GEM specific settings to AltSerialGraphicLCD library)
-    void setMenuPageCurrent(GEMPage& menuPageCurrent);   // Set supplied menu page as current
+    GEM_adafruit_gfx& setSplash(byte width, byte height, const uint8_t *image); // Set custom bitmap image displayed as the splash screen when GEM is being initialized. Should be called before GEM_adafruit_gfx::init().
+                                                                                // The following is the format of the bitmap as described in Adafruit GFX library documentation.
+                                                                                // A contiguous block of bits, where each '1' bit sets the corresponding pixel to 'color,' while each '0' bit is skipped.
+    GEM_adafruit_gfx& setSplashDelay(uint16_t value);                 // Set splash screen delay. Default value 1000ms, max value 65535ms. Setting to 0 will disable splash screen. Should be called before GEM::init().
+    GEM_adafruit_gfx& hideVersion(bool flag = true);                  // Turn printing of the current GEM library version on splash screen off or back on. Should be called before GEM::init().
+    GEM_adafruit_gfx& setTextSize(uint8_t size);                      // Set text 'magnification' size (as per Adafruit GFX docs); sprites will be scaled maximum up to two times regardless of the supplied value (default is 1)
+    GEM_adafruit_gfx& setForegroundColor(uint16_t color);             // Set foreground color of the menu (default is 0xFF)
+    GEM_adafruit_gfx& setBackgroundColor(uint16_t color);             // Set background color of the menu (default is 0x00)
+    GEM_adafruit_gfx& invertKeysDuringEdit(bool invert = true);       // Turn inverted order of characters during edit mode on or off
+    GEM_adafruit_gfx& init();                                         // Init the menu (load necessary sprites into RAM of the SparkFun Graphic LCD Serial Backpack, display GEM splash screen, etc.)
+    GEM_adafruit_gfx& reInit();                                       // Reinitialize the menu (apply GEM specific settings to AltSerialGraphicLCD library)
+    GEM_adafruit_gfx& setMenuPageCurrent(GEMPage& menuPageCurrent);   // Set supplied menu page as current
 
     /* CONTEXT OPERATIONS */
 
-    AppContext context;                                  // Currently set context
-    void clearContext();                                 // Clear context
+    AppContext context;                                               // Currently set context
+    GEM_adafruit_gfx& clearContext();                                 // Clear context
 
     /* DRAW OPERATIONS */
 
-    void drawMenu();                                     // Draw menu on screen, with menu page set earlier in GEM::setMenuPageCurrent()
+    GEM_adafruit_gfx& drawMenu();                                     // Draw menu on screen, with menu page set earlier in GEM::setMenuPageCurrent()
 
     /* KEY DETECTION */
 
-    bool readyForKey();                                  // Check that menu is waiting for the key press
-    void registerKeyPress(byte keyCode);                 // Register the key press and trigger corresponding action
-                                                         // Accepts GEM_KEY_NONE, GEM_KEY_UP, GEM_KEY_RIGHT, GEM_KEY_DOWN, GEM_KEY_LEFT, GEM_KEY_CANCEL, GEM_KEY_OK values
+    bool readyForKey();                                               // Check that menu is waiting for the key press
+    GEM_adafruit_gfx& registerKeyPress(byte keyCode);                 // Register the key press and trigger corresponding action
+                                                                      // Accepts GEM_KEY_NONE, GEM_KEY_UP, GEM_KEY_RIGHT, GEM_KEY_DOWN, GEM_KEY_LEFT, GEM_KEY_CANCEL, GEM_KEY_OK values
   private:
     Adafruit_GFX& _agfx;
     byte _menuPointerType;

--- a/src/GEM_u8g2.cpp
+++ b/src/GEM_u8g2.cpp
@@ -138,19 +138,22 @@ GEM_u8g2::GEM_u8g2(U8G2& u8g2_, byte menuPointerType_, byte menuItemsPerScreen_,
 
 //====================== INIT OPERATIONS
 
-void GEM_u8g2::setSplash(byte width, byte height, const unsigned char *image) {
+GEM_u8g2& GEM_u8g2::setSplash(byte width, byte height, const unsigned char *image) {
   _splash = {width, height, image};
+  return *this;
 }
 
-void GEM_u8g2::setSplashDelay(uint16_t value) {
+GEM_u8g2&  GEM_u8g2::setSplashDelay(uint16_t value) {
   _splashDelay = value;
+  return *this;
 }
 
-void GEM_u8g2::hideVersion(bool flag) {
+GEM_u8g2& GEM_u8g2::hideVersion(bool flag) {
   _enableVersion = !flag;
+  return *this;
 }
 
-void GEM_u8g2::enableCyrillic(bool flag) {
+GEM_u8g2& GEM_u8g2::enableCyrillic(bool flag) {
   _cyrillicEnabled = flag;
   if (_cyrillicEnabled) {
     _fontFamilies = {(uint8_t *)GEM_FONT_BIG_CYR, (uint8_t *)GEM_FONT_SMALL_CYR};
@@ -159,13 +162,15 @@ void GEM_u8g2::enableCyrillic(bool flag) {
     _fontFamilies = {(uint8_t *)GEM_FONT_BIG, (uint8_t *)GEM_FONT_SMALL};
     _u8g2.disableUTF8Print();
   }
+  return *this;
 }
 
-void GEM_u8g2::invertKeysDuringEdit(bool invert) {
+GEM_u8g2& GEM_u8g2::invertKeysDuringEdit(bool invert) {
   _invertKeysDuringEdit = invert;
+  return *this;
 }
 
-void GEM_u8g2::init() {
+GEM_u8g2& GEM_u8g2::init() {
   _u8g2.clear();
   _u8g2.setDrawColor(1);
   _u8g2.setFontPosTop();
@@ -207,9 +212,11 @@ void GEM_u8g2::init() {
     _u8g2.clear();
 
   }
+
+  return *this;
 }
 
-void GEM_u8g2::reInit() {
+GEM_u8g2& GEM_u8g2::reInit() {
   _u8g2.initDisplay();
   _u8g2.setPowerSave(0);
   _u8g2.clear();
@@ -220,24 +227,27 @@ void GEM_u8g2::reInit() {
   } else {
     _u8g2.disableUTF8Print();
   }
+  return *this;
 }
 
-void GEM_u8g2::setMenuPageCurrent(GEMPage& menuPageCurrent) {
+GEM_u8g2& GEM_u8g2::setMenuPageCurrent(GEMPage& menuPageCurrent) {
   _menuPageCurrent = &menuPageCurrent;
+  return *this;
 }
 
 //====================== CONTEXT OPERATIONS
 
-void GEM_u8g2::clearContext() {
+GEM_u8g2& GEM_u8g2::clearContext() {
   context.loop = nullptr;
   context.enter = nullptr;
   context.exit = nullptr;
   context.allowExit = true;
+  return *this;
 }
 
 //====================== DRAW OPERATIONS
 
-void GEM_u8g2::drawMenu() {
+GEM_u8g2& GEM_u8g2::drawMenu() {
   // _u8g2.clear(); // Not clearing for better performance
   _u8g2.firstPage();
   do {
@@ -246,6 +256,7 @@ void GEM_u8g2::drawMenu() {
     drawMenuPointer();
     drawScrollbar();
   } while (_u8g2.nextPage());
+  return *this;
 }
 
 void GEM_u8g2::drawTitleBar() {
@@ -857,9 +868,10 @@ bool GEM_u8g2::readyForKey() {
 
 }
 
-void GEM_u8g2::registerKeyPress(byte keyCode) {
+GEM_u8g2& GEM_u8g2::registerKeyPress(byte keyCode) {
   _currentKey = keyCode;
   dispatchKeyPress();
+  return *this;
 }
 
 void GEM_u8g2::dispatchKeyPress() {

--- a/src/GEM_u8g2.h
+++ b/src/GEM_u8g2.h
@@ -116,29 +116,29 @@ class GEM_u8g2 {
 
     /* INIT OPERATIONS */
 
-    void setSplash(byte width, byte height, const unsigned char *image); // Set custom XBM image displayed as the splash screen when GEM is being initialized. Should be called before GEM_u8g2::init().
-    void setSplashDelay(uint16_t value);                 // Set splash screen delay. Default value 1000ms, max value 65535ms. Setting to 0 will disable splash screen. Should be called before GEM_u8g2::init().
-    void hideVersion(bool flag = true);                  // Turn printing of the current GEM library version on splash screen off or back on. Should be called before GEM_u8g2::init().
-    void enableCyrillic(bool flag = true);               // Enable Cyrillic set of fonts. Generally should be called before GEM_u8g2::init(). To revert to non-Cyrillic fonts pass false: enableCyrillic(false).
-    void invertKeysDuringEdit(bool invert = true);       // Turn inverted order of characters during edit mode on or off
-    void init();                                         // Init the menu (set necessary settings, display GEM splash screen, etc.)
-    void reInit();                                       // Reinitialize the menu (call U8g2::initDisplay() and then reapply GEM specific settings)
-    void setMenuPageCurrent(GEMPage& menuPageCurrent);   // Set supplied menu page as current
+    GEM_u8g2& setSplash(byte width, byte height, const unsigned char *image); // Set custom XBM image displayed as the splash screen when GEM is being initialized. Should be called before GEM_u8g2::init().
+    GEM_u8g2& setSplashDelay(uint16_t value);                 // Set splash screen delay. Default value 1000ms, max value 65535ms. Setting to 0 will disable splash screen. Should be called before GEM_u8g2::init().
+    GEM_u8g2& hideVersion(bool flag = true);                  // Turn printing of the current GEM library version on splash screen off or back on. Should be called before GEM_u8g2::init().
+    GEM_u8g2& enableCyrillic(bool flag = true);               // Enable Cyrillic set of fonts. Generally should be called before GEM_u8g2::init(). To revert to non-Cyrillic fonts pass false: enableCyrillic(false).
+    GEM_u8g2& invertKeysDuringEdit(bool invert = true);       // Turn inverted order of characters during edit mode on or off
+    GEM_u8g2& init();                                         // Init the menu (set necessary settings, display GEM splash screen, etc.)
+    GEM_u8g2& reInit();                                       // Reinitialize the menu (call U8g2::initDisplay() and then reapply GEM specific settings)
+    GEM_u8g2& setMenuPageCurrent(GEMPage& menuPageCurrent);   // Set supplied menu page as current
 
     /* CONTEXT OPERATIONS */
 
-    AppContext context;                                  // Currently set context
-    void clearContext();                                 // Clear context
+    AppContext context;                                       // Currently set context
+    GEM_u8g2& clearContext();                                 // Clear context
 
     /* DRAW OPERATIONS */
 
-    void drawMenu();                                     // Draw menu on screen, with menu page set earlier in GEM_u8g2::setMenuPageCurrent()
+    GEM_u8g2& drawMenu();                                     // Draw menu on screen, with menu page set earlier in GEM_u8g2::setMenuPageCurrent()
 
     /* KEY DETECTION */
 
-    bool readyForKey();                                  // Check that menu is waiting for the key press
-    void registerKeyPress(byte keyCode);                 // Register the key press and trigger corresponding action
-                                                         // Accepts GEM_KEY_NONE, GEM_KEY_UP, GEM_KEY_RIGHT, GEM_KEY_DOWN, GEM_KEY_LEFT, GEM_KEY_CANCEL, GEM_KEY_OK values
+    bool readyForKey();                                       // Check that menu is waiting for the key press
+    GEM_u8g2& registerKeyPress(byte keyCode);                 // Register the key press and trigger corresponding action
+                                                              // Accepts GEM_KEY_NONE, GEM_KEY_UP, GEM_KEY_RIGHT, GEM_KEY_DOWN, GEM_KEY_LEFT, GEM_KEY_CANCEL, GEM_KEY_OK values
   private:
     U8G2& _u8g2;
     byte _menuPointerType;


### PR DESCRIPTION
* Support for chaining of method calls (as per #59 );
* Ability to specify parent menu page via `GEMPage` constructor (also #59 );
* Readme updated accordingly.