### PR TITLE
`GEMAppearance` struct; methods for traversing; disable AltSerialGraphicLCD version by default; Todo List example

### DIFF
--- a/README.md
+++ b/README.md
@@ -971,7 +971,7 @@ GEM_adafruit_gfx menu(tft[, appearance]);
 
 * **appearance** [*optional*]  
   *Type*: `GEMAppearance`  
-  Object of type `GEMAppearance` that holds values of appearance settings that define how menu is rendered on screen. Essentially allows to pass appearance as a single object instead of specifying each option as a aseparate argument.
+  Object of type `GEMAppearance` that holds values of appearance settings that define how menu is rendered on screen. Essentially allows to pass appearance as a single object instead of specifying each option as a separate argument.
 
 ![GEM customization](https://github.com/Spirik/GEM/wiki/images/customization.gif)
 
@@ -1748,7 +1748,6 @@ void setupMenu() {
   menuPageSettings.setAppearance(&appearanceSettings); // Note `&` operator
   ...
 }
-
 ```
 
 Alternatively:
@@ -1769,7 +1768,7 @@ void setupMenu() {
   // Create GEMAppearance object with general values (that will be used for every menu page if not overridden)
   GEMAppearance appearanceGeneral;
   appearanceGeneral.menuPointerType = GEM_POINTER_ROW;
-  appearanceGeneral.menuItemsPerScreen = 5;
+  appearanceGeneral.menuItemsPerScreen = GEM_ITEMS_COUNT_AUTO;
   appearanceGeneral.menuItemHeight = 10;
   appearanceGeneral.menuPageScreenTopOffset = 10;
   appearanceGeneral.menuValuesLeftOffset = 86;
@@ -1783,8 +1782,9 @@ void setupMenu() {
   menuPageSettings.setAppearance(&appearanceSettings); // Note `&` operator
   ...
 }
-
 ```
+
+Passing `GEMAppearance` object to `GEMPage::setAppearance()` method as a pointer allows to change appearance dynamically by changing values stored in object (and making sure that `menu.drawMenu();` is called afterwards) without need for additional call to `GEMPage::setAppearance()`. In contrast, to change general appearance of the menu (and not individual page) `menu.setAppearance(appearanceGeneral);` method should be called with new or updated `GEMAppearance` object supplied as an argument (and `menu.drawMenu();` should be called afterwards as well).
 
 For more details about appearance customization see corresponding section of the [wiki](https://github.com/Spirik/GEM/wiki).
 
@@ -1870,7 +1870,6 @@ void buttonContextExit() {
   // Clear context (assigns `nullptr` values to function pointers of the `context` property of the `GEM` object and resets `allowExit` flag to its default state)
   menu.clearContext();
 }
-
 ```
 
 To exit currently running context and return to menu, press button associated with `GEM_KEY_CANCEL` key (only if `context.allowExit` flag is set to its default value of `true`, otherwise you should handle exit from the loop manually and call `context.exit()` explicitly) - `context.exit()` callback will be called.

--- a/README.md
+++ b/README.md
@@ -1916,7 +1916,7 @@ It is possible to configure GEM library by excluding some features not needed in
 
 You can also choose which version of GEM library (`AltSerialGraphicLCD`, `U8g2` or `Adafruit GFX` based) should be compiled. That way, there won't be requirement to have all of the supported graphics libraries installed in the system at the same time (regardless of which one is actually used).
 
-Currently there are two ways of achieving  that.
+Currently there are two ways of achieving that.
 
 ### Manual `config.h` edition
 
@@ -1960,7 +1960,7 @@ build_flags =
 
 Compatibility
 -----------
-Some boards (e.g. ESP32, ESP8266, RP2040, nRF52840, etc. based boards) are not supported in AltSerialGraphicLCD version of GEM: this library should be commented out in [config.h](https://github.com/Spirik/GEM/blob/master/src/config.h) before compiling.
+Some boards (e.g. ESP32, ESP8266, RP2040, nRF52840, etc. based boards) are not supported in AltSerialGraphicLCD version of GEM: this library should not be enabled in [Configuration](#configuration) before compiling for these boards.
 
 When support for [Floating-point variables](#floating-point-variables) is enabled, GEM relies on `dtostrf()` function to handle conversion to a string, which may not be available for all of the architectures supported by Arduino by default. You may have to manually include support for it, e.g., via explicit inclusion of suitable version of `dtostrf.h` header file in `GEM.cpp`, `GEM_u8g2.cpp` or `GEM_adafruit_gfx.cpp` source files. It is available for AVR-based boards by default and currently it is explicitly included for SAMD boards (e.g. with M0 chips), RP2040 and nRF52840 based boards. ESP32 based boards should be fine as well.
 

--- a/README.md
+++ b/README.md
@@ -1176,6 +1176,10 @@ For more details on customization see corresponding section of the [wiki](https:
   *Returns*: `GEM&`, or `GEM_u8g2&`, or `GEM_adafruit_gfx&`  
   Set supplied menu page as current. Accepts `GEMPage` object.
 
+* *GEMPage** **getCurrentMenuPage()**  
+  *Returns*: `GEMPage*&`  
+  Get pointer to currently active menu page.
+
 * *GEM&* **drawMenu()**  
   *Returns*: `GEM&`, or `GEM_u8g2&`, or `GEM_adafruit_gfx&`  
   Draw menu on screen, with menu page set earlier in `setMenuPageCurrent()`.
@@ -1277,6 +1281,14 @@ GEMPage menuPage(title[, parentMenuPage]);
   *Accepts*: `byte`[, `bool`]  
   *Returns*: `GEMItem*`  
   Get pointer to menu item on this page by index, counting hidden ones (if **total** set to `true`, or `GEM_ITEMS_TOTAL`) or only visible (if **total** set to `false`, or `GEM_ITEMS_VISIBLE`).
+
+* *GEMItem** **getCurrentMenuItem()**  
+  *Returns*: `GEMItem*`  
+  Get pointer to currently focused menu item on this page.
+
+* *byte* **getCurrentMenuItemIndex()**  
+  *Returns*: `byte`  
+  Get index of currently focused menu item on this page.
 
 > **Note:** calls to methods that return a reference to the owning `GEMPage` object can be chained, e.g. `menuPageSettings.addMenuItem(menuItemInterval).addMenuItem(menuItemTempo).setParentMenuPage(menuPageMain);` (since GEM ver. 1.4.6).
 

--- a/README.md
+++ b/README.md
@@ -1784,7 +1784,7 @@ void setupMenu() {
 }
 ```
 
-Passing `GEMAppearance` object to `GEMPage::setAppearance()` method as a pointer allows to change appearance dynamically by changing values stored in object (and making sure that `menu.drawMenu();` is called afterwards) without need for additional call to `GEMPage::setAppearance()`. In contrast, to change general appearance of the menu (and not individual page) `menu.setAppearance(appearanceGeneral);` method should be called with new or updated `GEMAppearance` object supplied as an argument (and `menu.drawMenu();` should be called afterwards as well).
+Passing `GEMAppearance` object to `GEMPage::setAppearance()` method as a pointer allows to change appearance of the _individual menu page_ dynamically by changing values stored in object (and making sure that `menu.drawMenu();` is called afterwards) without need for additional call to `GEMPage::setAppearance()`. In contrast, to change _general appearance_ of the menu (and not individual page) `menu.setAppearance(appearanceGeneral);` method should be called with new or updated `GEMAppearance` object supplied as an argument (and `menu.drawMenu();` should be called afterwards as well).
 
 For more details about appearance customization see corresponding section of the [wiki](https://github.com/Spirik/GEM/wiki).
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Supports [AltSerialGraphicLCD](http://www.jasspa.com/serialGLCD.html) (since GEM
   * [GEMItem](#gemitem)
   * [GEMSelect](#gemselect)
   * [GEMCallbackData](#gemcallbackdata)
+  * [GEMAppearance](#gemappearance)
   * [AppContext](#appcontext)
 * [Floating-point variables](#floating-point-variables)
 * [Configuration](#configuration)
@@ -886,12 +887,18 @@ Reference
 
 ### GEM, GEM_u8g2, GEM_adafruit_gfx
 
-Primary class of the library. Responsible for appearance of the menu, communication with display (via supplied `GLCD`, `U8G2` or `Adafruit_GFX` object), integration of all menu items `GEMItem` and pages `GEMPage` into one menu. Object of corresponding `GEM` class variation defines as follows.
+Primary class of the library. Responsible for general appearance of the menu, communication with display (via supplied `GLCD`, `U8G2` or `Adafruit_GFX` object), integration of all menu items `GEMItem` and pages `GEMPage` into one menu. Object of corresponding `GEM` class variation defines as follows.
 
 AltSerialGraphicLCD version:
 
 ```cpp
 GEM menu(glcd[, menuPointerType[, menuItemsPerScreen[, menuItemHeight[, menuPageScreenTopOffset[, menuValuesLeftOffset]]]]]);
+```
+
+or
+
+```cpp
+GEM menu(glcd[, appearance]);
 ```
 
 U8g2 version:
@@ -900,10 +907,22 @@ U8g2 version:
 GEM_u8g2 menu(u8g2[, menuPointerType[, menuItemsPerScreen[, menuItemHeight[, menuPageScreenTopOffset[, menuValuesLeftOffset]]]]]);
 ```
 
+or
+
+```cpp
+GEM_u8g2 menu(u8g2[, appearance]);
+```
+
 Adafruit GFX version:
 
 ```cpp
 GEM_adafruit_gfx menu(tft[, menuPointerType[, menuItemsPerScreen[, menuItemHeight[, menuPageScreenTopOffset[, menuValuesLeftOffset]]]]]);
+```
+
+or
+
+```cpp
+GEM_adafruit_gfx menu(tft[, appearance]);
 ```
 
 * **glcd**  `AltSerialGraphicLCD version`  
@@ -950,6 +969,10 @@ GEM_adafruit_gfx menu(tft[, menuPointerType[, menuItemsPerScreen[, menuItemHeigh
   *Default*: `86`  
   Offset from the left of the screen to the value of variable associated with the menu item (effectively the space left for the title of the menu item to be printed on screen). Default value is suitable for 128x64 screen with other parameters at their default values; 86 - recommended value for 128x64 screen.
 
+* **appearance** [*optional*]  
+  *Type*: `GEMAppearance`  
+  Object of type `GEMAppearance` that holds values of appearance settings that define how menu is rendered on screen. Essentially allows to pass appearance as a single object instead of specifying each option as a aseparate argument.
+
 ![GEM customization](https://github.com/Spirik/GEM/wiki/images/customization.gif)
 
 Calls to `GEM`, `GEM_u8g2` or `GEM_adafruit_gfx` constructors `GEM(glcd)`, `GEM_u8g2(u8g2)`, `GEM_adafruit_gfx(tft)` without specifying additional custom parameters are equivalent to the following calls:
@@ -970,7 +993,9 @@ GEM_adafruit_gfx menu(tft, /* menuPointerType= */ GEM_POINTER_ROW, /* menuItemsP
 
 > **Note:** long title of the menu page `GEMPage` won't overflow to the new line in U8g2 version and will be truncated at the edge of the screen.
 
-For more details on customization see corresponding section of the [wiki](https://github.com/Spirik/GEM/wiki).
+> **Note:** it is possible to customize appearance of each menu page individually (since GEM ver. 1.5) by using [`GEMAppearance`](#gemappearance) object.
+
+For more details on customization see corresponding section of the [wiki](https://github.com/Spirik/GEM/wiki) and description of [`GEMAppearance`](#gemappearance) struct.
 
 #### Constants
 
@@ -1055,6 +1080,11 @@ For more details on customization see corresponding section of the [wiki](https:
   Alias for the keys (buttons) used to navigate and interact with menu. Submitted to `GEM::registerKeyPress()`, `GEM_u8g2::registerKeyPress()` and `GEM_adafruit_gfx::registerKeyPress()` methods. Indicates that Ok/Apply key is pressed (toggle `bool` menu item, enter edit mode of the associated non-`bool` variable, exit edit mode with saving the variable, execute code associated with button).
 
 #### Methods
+
+* *GEM&* **setAppearance(** _GEMAppearance_ appearance **)**  
+  *Accepts*: `GEMAppearance`  
+  *Returns*: `GEM&`, or `GEM_u8g2&`, or `GEM_adafruit_gfx&`  
+  Set general appearance of the menu (can be overridden in `GEMPage` on per page basis).
 
 * *GEM&* **setSplash(** _const uint8_t PROGMEM_ *sprite **)**  `AltSerialGraphicLCD version`  
   *Accepts*: `_const uint8_t PROGMEM_ *`  
@@ -1228,7 +1258,7 @@ GEMPage menuPage(title[, parentMenuPage]);
 * *GEMPage&* **setParentMenuPage(** _GEMPage&_ parentMenuPage **)**  
   *Accepts*: `GEMPage`  
   *Returns*: `GEMPage&`  
-  Specify parent level menu page (to know where to go back to when pressing Back button, which will be added automatically). Accepts `GEMPage` object. If called additional time, previously added parent menu page will be overriden with the new one.
+  Specify parent level menu page (to know where to go back to when pressing Back button, which will be added automatically). Accepts `GEMPage` object. If called additional time, previously added parent menu page will be overridden with the new one.
 
 * *GEMPage&* **setTitle(** _const char*_ title **)**  
   *Returns*: `GEMPage&`  
@@ -1237,6 +1267,11 @@ GEMPage menuPage(title[, parentMenuPage]);
 * *const char** **getTitle()**  
   *Returns*: `const char*`  
   Get title of the menu page.
+
+* *GEMPage&* **setAppearance(** _GEMAppearance*_ appearance **)**  
+  *Accepts*: `GEMAppearance*`  
+  *Returns*: `GEMPage&`  
+  Set appearance of the menu page. Note that appearance should be passed as a pointer to [`GEMAppearance`](#gemappearance) object. And as such, `GEMAppearance` object should be declared in a global scope.
 
 > **Note:** calls to methods that return a reference to the owning `GEMPage` object can be chained, e.g. `menuPageSettings.addMenuItem(menuItemInterval).addMenuItem(menuItemTempo).setParentMenuPage(menuPageMain);` (since GEM ver. 1.4.6).
 
@@ -1652,6 +1687,106 @@ void buttonAction(GEMCallbackData callbackData) {
 ```
 
 For more details and examples of using user-defined callback arguments see corresponding sections of the [wiki](https://github.com/Spirik/GEM/wiki).
+
+
+----------
+
+
+### GEMAppearance
+
+Data structure that holds values of appearance settings that define how menu is rendered on screen. Can be submitted to `GEM` (`GEM_u8g2`, `GEM_adafruit_gfx`) constructor instead of specifying each option as a separate argument, or passed as an argument to `GEM::setAppearance()` (`GEM_u8g2::setAppearance()`, `GEM_adafruit_gfx::setAppearance()`) method to set general appearance of the menu (that will be used for every menu page if not overridden). Pointer to object of type `GEMAppearance` can be passed to `GEMPage::setAppearance()` method to customize appearance of corresponding menu page individually.
+
+Object of type `GEMAppearance` defines as follows:
+
+```cpp
+GEMAppearance appearanceGeneral = {menuPointerType, menuItemsPerScreen, menuItemHeight, menuPageScreenTopOffset, menuValuesLeftOffset}
+```
+
+* **menuPointerType**  
+  *Type*: `byte`  
+  *Values*: `GEM_POINTER_ROW`, `GEM_POINTER_DASH`  
+  Type of menu pointer visual appearance: either highlighted row or pointer to the left of the row.
+
+* **menuItemsPerScreen**  
+  *Type*: `byte`   
+  *Values*: number, `GEM_ITEMS_COUNT_AUTO` (alias for `0`)  
+  Count of the menu items per screen. Suitable for 128x64 screen with other variables at their default values. If set to `GEM_ITEMS_COUNT_AUTO`, the number of menu items will be determined automatically based on actual height of the screen.
+
+* **menuItemHeight**  
+  *Type*: `byte`  
+  *Units*: dots  
+  Height of the menu item. Suitable for 128x64 screen with other variables at their default values.
+
+* **menuPageScreenTopOffset**  
+  *Type*: `byte`  
+  *Units*: dots  
+  Offset from the top of the screen to accommodate title of the menu page. Suitable for 128x64 screen with other variables at their default values.
+
+* **menuValuesLeftOffset**  
+  *Type*: `byte`  
+  *Units*: dots  
+  Offset from the left of the screen to the value of the associated with menu item variable (effectively the space left for the title of the menu item to be printed on screen). Suitable for 128x64 screen with other variables at their default values; 86 - recommended value for 128x64 screen.
+
+Basic example of use:
+
+```cpp
+// Create GEMAppearance object with general values (that will be used for every menu page if not overridden)
+GEMAppearance appearanceGeneral = {/* menuPointerType= */ GEM_POINTER_ROW, /* menuItemsPerScreen= */ GEM_ITEMS_COUNT_AUTO, /* menuItemHeight= */ 10, /* menuPageScreenTopOffset= */ 10, /* menuValuesLeftOffset= */ 86}
+// Create GEMAppearance object as a copy of appearanceGeneral (its values can be customized later in sketch).
+// Note that it should be created in a global scope of the sketch (in order to be passed as a pointer to menu page)
+GEMAppearance appearanceSettings = appearanceGeneral;
+
+// Create menu object (and pass appearanceGeneral as an argument to constructor)
+GEM menu(glcd, appearanceGeneral);
+
+...
+
+// Later in sketch, e.g. in setupMenu()
+void setupMenu() {
+  ...
+  appearanceSettings.menuValuesLeftOffset = 70;
+  menuPageSettings.setAppearance(&appearanceSettings); // Note `&` operator
+  ...
+}
+
+```
+
+Alternatively:
+
+```cpp
+// Create empty GEMAppearance object (its values can be populated later in sketch).
+// Note that it should be created in a global scope of the sketch (in order to be passed as a pointer to menu page)
+GEMAppearance appearanceSettings;
+
+// Create menu object (its appearance settings will be populated with defaut values)
+GEM menu(glcd);
+
+...
+
+// Later in sketch, e.g. in setupMenu()
+void setupMenu() {
+  ...
+  // Create GEMAppearance object with general values (that will be used for every menu page if not overridden)
+  GEMAppearance appearanceGeneral;
+  appearanceGeneral.menuPointerType = GEM_POINTER_ROW;
+  appearanceGeneral.menuItemsPerScreen = 5;
+  appearanceGeneral.menuItemHeight = 10;
+  appearanceGeneral.menuPageScreenTopOffset = 10;
+  appearanceGeneral.menuValuesLeftOffset = 86;
+
+  // Set appearanceGeneral as a general appearance of the menu
+  menu.setAppearance(appearanceGeneral); // Note there is no `&` operator when setting general (or global) appearance of the menu
+
+  // Copy values from appearanceGeneral object to appearanceSettings for further customization
+  appearanceSettings = appearanceGeneral;
+  appearanceSettings.menuValuesLeftOffset = 70;
+  menuPageSettings.setAppearance(&appearanceSettings); // Note `&` operator
+  ...
+}
+
+```
+
+For more details about appearance customization see corresponding section of the [wiki](https://github.com/Spirik/GEM/wiki).
 
 
 ----------

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Supports buttons that can invoke user-defined actions and create action-specific
 
 Supports [AltSerialGraphicLCD](http://www.jasspa.com/serialGLCD.html) (since GEM ver. 1.0), [U8g2](https://github.com/olikraus/U8g2_Arduino) (since GEM ver. 1.1) and [Adafruit GFX](https://learn.adafruit.com/adafruit-gfx-graphics-library) (since GEM ver. 1.3) graphics libraries.
 
-> Note that each of AltSerialGraphicLCD, U8g2 and Adafruit GFX libraries are required by default, regardless of which one of them is actually used to drive display (although the ones that are not used shouldn't affect compiled sketch size much). However, it is possible (since GEM ver. 1.2.2) to exclude support for not used ones. See [Configuration](#configuration) section for details.
+> Note that U8g2 and Adafruit GFX libraries are required by default, regardless of which one of them is actually used to drive display (although the ones that are not used shouldn't affect compiled sketch size much). However, it is possible (since GEM ver. 1.2.2) to exclude support for not used ones. Support for `AltSerialGraphicLCD` is disabled by default since GEM ver. 1.5 (it is still possible to enable it). See [Configuration](#configuration) section for details.
 
 > For use with AltSerialGraphicLCD library (by Jon Green) LCD screen must be equipped with [SparkFun Graphic LCD Serial Backpack](https://www.sparkfun.com/products/9352) and properly set up to operate using firmware provided with aforementioned library.
 
@@ -69,7 +69,7 @@ Library format is compatible with Arduino IDE 1.5.x+. There are two ways to inst
 
 Whichever option you choose you may need to reload IDE afterwards.
 
-Each of [AltSerialGraphicLCD](http://www.jasspa.com/serialGLCD.html), [U8g2](https://github.com/olikraus/U8g2_Arduino) and [Adafruit GFX](https://learn.adafruit.com/adafruit-gfx-graphics-library) libraries are required to be installed by default as well. However, it is possible (since GEM ver. 1.2.2) to exclude support for not used ones. See [Configuration](#configuration) section for details.
+[U8g2](https://github.com/olikraus/U8g2_Arduino) and [Adafruit GFX](https://learn.adafruit.com/adafruit-gfx-graphics-library) libraries are required to be installed by default as well. Support for [AltSerialGraphicLCD](http://www.jasspa.com/serialGLCD.html) is disabled by default since GEM ver. 1.5 (so it is not required to be installed). However, it is possible to exclude support for not used libraries (since GEM ver. 1.2.2), and/or enable support for `AltSerialGraphicLCD` (since GEM ver 1.5). See [Configuration](#configuration) section for details.
 
 How to use with AltSerialGraphicLCD
 -----------------------------------
@@ -79,7 +79,7 @@ How to use with AltSerialGraphicLCD
 
 ### Requirements
 
-GEM supports [AltSerialGraphicLCD](http://www.jasspa.com/serialGLCD.html) library. LCD screen must be equipped with [SparkFun Graphic LCD Serial Backpack](https://www.sparkfun.com/products/9352) and properly set up to operate using firmware provided with AltSerialGraphicLCD. Installation and configuration of it is covered in great detail in AltSerialGraphicLCD manual.
+GEM supports [AltSerialGraphicLCD](http://www.jasspa.com/serialGLCD.html) library if enabled (see [Configuration](#configuration) section). LCD screen must be equipped with [SparkFun Graphic LCD Serial Backpack](https://www.sparkfun.com/products/9352) and properly set up to operate using firmware provided with AltSerialGraphicLCD. Installation and configuration of it is covered in great detail in AltSerialGraphicLCD manual.
 
 In theory GEM is compatible with any display, that is supported by SparkFun Graphic LCD Serial Backpack. Guaranteed to work with [128x64](https://www.sparkfun.com/products/710) pixel displays. [160x128](https://www.sparkfun.com/products/8799) pixel ones should work fine as well, although it wasn't tested.
 
@@ -1922,19 +1922,19 @@ Currently there are two ways of achieving  that.
 
 For that, locate file [config.h](https://github.com/Spirik/GEM/blob/master/src/config.h) that comes with the library, open it and comment out corresponding inclusion.
 
-To disable `AltSerialGraphicLCD` support comment out the following line:
+Support for `AltSerialGraphicLCD` is disabled by default since GEM ver. 1.5. To _enable_ `AltSerialGraphicLCD` support comment out the following line:
 
 ```cpp
-#include "config/enable-glcd.h"
+#define GEM_DISABLE_GLCD
 ```
 
-To disable `U8g2` support comment out the following line:
+To _disable_ `U8g2` support comment out the following line:
 
 ```cpp
 #include "config/enable-u8g2.h"
 ```
 
-To disable `Adafruit GFX` support comment out the following line:
+To _disable_ `Adafruit GFX` support comment out the following line:
 
 ```cpp
 #include "config/enable-adafruit-gfx.h"
@@ -1950,8 +1950,8 @@ Alternatively, define corresponding flag before build. E.g. in [PlatformIO](http
 
 ```ini
 build_flags =
-    ; Disable AltSerialGraphicLCD support
-    -D GEM_DISABLE_GLCD
+    ; Enable AltSerialGraphicLCD support
+    -D GEM_ENABLE_GLCD
     ; Disable U8g2 support
     -D GEM_DISABLE_U8G2
     ; Disable Adafruit GFX support

--- a/README.md
+++ b/README.md
@@ -1250,7 +1250,7 @@ GEMPage menuPage(title[, parentMenuPage]);
 
 #### Methods
 
-* *GEMPage&* **addMenuItem(** _GEMItem&_ menuItem, [_byte_ pos = 255[, _bool_ total = true]] **)**  
+* *GEMPage&* **addMenuItem(** _GEMItem&_ menuItem[, _byte_ pos = 255[, _bool_ total = true]] **)**  
   *Accepts*: `GEMItem`[, `byte`[, `bool`]]  
   *Returns*: `GEMPage&`  
   Add menu item to menu page. Accepts `GEMItem` object. Optionally menu item can be added at a specified position **pos** (zero-based number from 0 to 255, as a second argument) out of total (flag **total** set to `true`, or `GEM_ITEMS_TOTAL`, as a third argument) or only visible (flag **total** set to `false`, or `GEM_ITEMS_VISIBLE`, as a third argument) number of items. Note that if **pos** is set to 0 and menu page has parent menu page, menu item will be added at position 1 instead (i.e. as a second menu item, after built-in Back button). By default (if optional arguments are not provided) each menu item is added at the end of the list of menu items of the page (including hidden ones).
@@ -1272,6 +1272,11 @@ GEMPage menuPage(title[, parentMenuPage]);
   *Accepts*: `GEMAppearance*`  
   *Returns*: `GEMPage&`  
   Set appearance of the menu page. Note that appearance should be passed as a pointer to [`GEMAppearance`](#gemappearance) object. And as such, `GEMAppearance` object should be declared in a global scope.
+
+* *GEMItem** **getMenuItem(** _byte_ index[, _bool_ total = false] **)**  
+  *Accepts*: `byte`[, `bool`]  
+  *Returns*: `GEMItem*`  
+  Get pointer to menu item on this page by index, counting hidden ones (if **total** set to `true`, or `GEM_ITEMS_TOTAL`) or only visible (if **total** set to `false`, or `GEM_ITEMS_VISIBLE`).
 
 > **Note:** calls to methods that return a reference to the owning `GEMPage` object can be chained, e.g. `menuPageSettings.addMenuItem(menuItemInterval).addMenuItem(menuItemTempo).setParentMenuPage(menuPageMain);` (since GEM ver. 1.4.6).
 
@@ -1479,6 +1484,11 @@ GEMItem menuItemButton(title, buttonAction[, callbackVal[, readonly]]);
 * *void** **getLinkedVariablePointer()**  
   *Returns*: `void*`  
   Get pointer to a linked variable (relevant for menu items that represent variable). Note that user is reponsible for casting `void*` pointer to a correct pointer type.
+
+* *GEMItem** **getMenuItemNext(** _bool_ total = false **)**  
+  *Accepts*: `bool`  
+  *Returns*: `GEMItem*`  
+  Get pointer to next menu item, i.e. menu item that follows this one on the menu page, including hidden ones (if **total** set to `true`, or `GEM_ITEMS_TOTAL`) or only visible (if **total** set to `false`, or `GEM_ITEMS_VISIBLE`).
 
 > **Note:** calls to methods that return a reference to the owning `GEMItem` object can be chained, e.g. `menuItemInterval.setReadonly().show();` (since GEM ver. 1.4.6).
 

--- a/README.md
+++ b/README.md
@@ -1455,6 +1455,11 @@ GEMItem menuItemButton(title, buttonAction[, callbackVal[, readonly]]);
   *Returns*: `GEMItem&`  
   Explicitly set precision for `float` or `double` variable as required by [`dtostrf()`](http://www.nongnu.org/avr-libc/user-manual/group__avr__stdlib.html#ga060c998e77fb5fc0d3168b3ce8771d42) conversion used internally, i.e. the number of digits **after** the decimal sign.
 
+* *GEMItem&* **setAdjustedASCIIOrder(** _bool_ mode = true **)**  
+  *Accepts*: `bool`  
+  *Returns*: `GEMItem&`  
+  Turn adjsuted order of characters when editing `char[17]` variables on (`setAdjustedASCIIOrder()`, or `setAdjustedASCIIOrder(true)`) or off (`setAdjustedASCIIOrder(false)`). When adjsuted order is enabled, space character is followed by "a" and preceded by "\`" (grave accent character). By default adjusted order is disabled, and characters follow order in ASCII table (space character is followed by "!"). Adjusted order can be more suitable for editing text variables in certain use cases (so user won't have to scroll past all of the special characters to get to alphabet).
+
 * *GEMItem&* **setReadonly(** _bool_ mode = true **)**  
   *Accepts*: `bool`  
   *Returns*: `GEMItem&`  

--- a/examples/AdafruitGFX/Example-06_Todo-List/Example-06_Todo-List.ino
+++ b/examples/AdafruitGFX/Example-06_Todo-List/Example-06_Todo-List.ino
@@ -1,0 +1,517 @@
+/*
+  Using GEM to create Todo list utilizing (god-forbidden) dynamic memory allocation (`new` and `delete`).
+  Using rotary encoder as an input source. Todo items can be dynamically added to the list,
+  marked completed and cleared (removed from the list). Additional settings are provided
+  (e.g. changing menu pointer style and order of characters in edit mode).
+
+  Note, that generally it is not recommended to implement dynamic memory allocation in microcontroller-based
+  projects for a number of reasons (mostly due to memory limitations and lack of supervisory OS to handle
+  memory management). Consider this example as an experiment and merely demonstration of some of the GEM
+  features, rather than a guide on how to manage dynamic memory in your project.
+
+  Adafruit GFX library is used to draw menu.
+  KeyDetector library (version 1.2.0 or later) is used to detect rotary encoder operation.
+
+  Points of improvement to consider:
+  - Prevent adding new Todo items if insufficient amount of RAM is available
+  - Add button to Uncheck all and/or Check all Todo items
+  - Use external storage (e.g. SD Card) to store data
+  - Make portable by adding battery
+  
+  This example uses the same schematics/breadboard as Example-05_Encoder (supplied with GEM).
+
+  Additional info (including the breadboard view) available on GitHub:
+  https://github.com/Spirik/GEM
+  
+  This example code is in the public domain.
+*/
+
+#include <GEM_adafruit_gfx.h>
+#include <KeyDetector.h>
+
+// SPI and I2C libraries required by SH1106 display
+//#include <SPI.h>
+#include <Wire.h>
+#include <Adafruit_GFX.h>
+
+// Hardware-specific library for SH1106.
+// Include library that matches your setup (see https://learn.adafruit.com/adafruit-gfx-graphics-library for details)
+#include <Adafruit_SH110X.h>
+
+//====================== CLASSES
+
+// Class representing Todo item
+class TodoItem {
+  public:
+    /* 
+      @param 'title_' - title of Todo item
+    */
+    TodoItem(char* title_){
+      strcpy(title, title_);
+      menuItem = new GEMItem(title, completed);
+    };
+
+    char title[GEM_STR_LEN];      // Title of Todo item
+    bool completed = false;       // Checkbox status
+    GEMItem* menuItem = nullptr;  // Pointer to corresponding menu item
+};
+
+//====================== MISC
+
+// Custom splash (disabled, because it won't be visible on the screen of buffer-equiped displays
+// such as this one with Adafruit GFX library)
+/* #define splashWidth  27
+#define splashHeight 8
+static const unsigned char splashBits [] PROGMEM = {
+  0xf8, 0xe3, 0xc3, 0x80, 0x01, 0x10, 0x24, 0x40, 0x21, 0x12, 0x24, 0x40, 0x21, 0x12, 0x24, 0x40, 
+	0x21, 0x12, 0x24, 0x40, 0x21, 0x12, 0x24, 0x40, 0x20, 0xe3, 0xc3, 0x80, 0x00, 0x00, 0x00, 0x00
+}; */
+
+//====================== WORKING WITH ENCODER
+
+// Define signal identifiers for three outputs of encoder (channel A, channel B and a push-button)
+#define KEY_A 1
+#define KEY_B 2
+#define KEY_C 3
+
+// Pins encoder is connected to
+const byte channelA = 2;
+const byte channelB = 3;
+const byte buttonPin = 4;
+
+// Array of Key objects that will link GEM key identifiers with dedicated pins
+// (it is only necessary to detect signal change on a single channel of the encoder, either A or B;
+// order of the channel and push-button Key objects in an array is not important)
+Key keys[] = {{KEY_A, channelA}, {KEY_C, buttonPin}};
+
+// Create KeyDetector object
+// KeyDetector myKeyDetector(keys, sizeof(keys)/sizeof(Key));
+// To account for switch bounce effect of the buttons (if occur) you may want to specify debounceDelay
+// as the third argument to KeyDetector constructor.
+// Make sure to adjust debounce delay to better fit your rotary encoder.
+// Also it is possible to enable pull-up mode when buttons wired with pull-up resistors (as in this case).
+// Analog threshold is not necessary for this example and is set to default value 16.
+KeyDetector myKeyDetector(keys, sizeof(keys)/sizeof(Key), /* debounceDelay= */ 10, /* analogThreshold= */ 16, /* pullup= */ true);
+
+bool secondaryPressed = false;  // If encoder rotated while key was being pressed; used to prevent unwanted triggers
+bool cancelPressed = false;  // Flag indicating that Cancel action was triggered, used to prevent it from triggering multiple times
+const int keyPressDelay = 1000; // How long to hold key in pressed state to trigger Cancel action, ms
+long keyPressTime = 0; // Variable to hold time of the key press event
+long now; // Variable to hold current time taken with millis() function at the beginning of loop()
+
+//====================== OBTAINING RAM STATUS
+
+// Variable to store free RAM. It is an int, so overflows and rollover may occur, in that case, free RAM won't be displayed
+int freeRam;
+GEMItem menuItemRam("Free RAM:", freeRam, GEM_READONLY); // Menu item associated with it
+
+// Free RAM calculations
+// (based on https://docs.arduino.cc/learn/programming/memory-guide and https://github.com/mpflaga/Arduino-MemoryFree/)
+#if defined(__arm__) && !defined(ARDUINO_ARCH_RP2040)
+// ARM (except RP2040, which won't display correct values, probably due to internal implementation)
+
+extern "C" char* sbrk(int incr);
+
+void calculateFreeRam() {
+  freeRam = getFreeRam();
+}
+
+int getFreeRam() {
+  char top;
+  return &top - reinterpret_cast<char*>(sbrk(0));
+}
+
+#elif defined(ARDUINO_ARCH_AVR)
+// ARM
+
+void calculateFreeRam() {
+  freeRam = getFreeRam();
+}
+
+int getFreeRam() {
+  extern int __heap_start,*__brkval;
+  int v;
+  return (int)&v - (__brkval == 0 ? (int)&__heap_start : (int) __brkval);
+}
+
+#elif defined(ARDUINO_ARCH_ESP32)
+// ESP32
+
+void calculateFreeRam() {
+  freeRam = ESP.getFreeHeap();
+}
+
+#else
+// Correct detection of free RAM not implemented
+
+void calculateFreeRam() {
+  freeRam = -1;
+}
+
+#endif
+
+//====================== DISPLAY
+
+/* Uncomment to initialize the I2C address, uncomment only one, if you get a totally blank screen try the other */
+#define i2c_Address 0x3c // Initialize with the I2C addr 0x3C Typically eBay OLED's
+//#define i2c_Address 0x3d // Initialize with the I2C addr 0x3D Typically Adafruit OLED's
+
+// Macro constants (aliases) for display setup
+#define SCREEN_WIDTH 128 // OLED display width, in pixels
+#define SCREEN_HEIGHT 64 // OLED display height, in pixels
+#define OLED_RESET -1    //   QT-PY / XIAO
+
+// Create an instance of the Adafruit GFX library.
+// Use constructor that matches your setup (see https://learn.adafruit.com/adafruit-gfx-graphics-library for details).
+// SH1106 based display is used in the example.
+// This instance is used to call all the subsequent Adafruit GFX functions (internally from GEM library,
+// or manually in your sketch if it is required)
+Adafruit_SH1106G display = Adafruit_SH1106G(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET);
+
+//====================== MENU AND CORRESPONDING ELEMENTS
+
+// Create variable that will be editable through option select and create associated option select.
+// This variable will be passed to menu.invertKeysDuringEdit(), and naturally can be presented as a boolean,
+// but is declared as a byte type to be used in an option select rather than checkbox (for demonstration purposes)
+byte invert = 1;
+SelectOptionByte selectInvertOptions[] = {{"Invert", 1}, {"Normal", 0}};
+GEMSelect selectInvert(sizeof(selectInvertOptions)/sizeof(SelectOptionByte), selectInvertOptions);
+
+// Create menu item for option select with applyInvert() callback function
+void applyInvert(); // Forward declaration
+GEMItem menuItemInvert("Chars order:", invert, selectInvert, applyInvert);
+
+// Create variable holding appearance of menu pointer that will be editable through option select and create associated option select.
+byte menuPointer = GEM_POINTER_ROW;
+SelectOptionByte selectMenuPointerOptions[] = {{"Row", GEM_POINTER_ROW}, {"Dash", GEM_POINTER_DASH}};
+GEMSelect selectMenuPointer(sizeof(selectMenuPointerOptions)/sizeof(SelectOptionByte), selectMenuPointerOptions);
+
+// Create menu item for option select with applyMenuPointer() callback function
+void applyMenuPointer(); // Forward declaration
+GEMItem menuItemMenuPointer("Menu pointer:", menuPointer, selectMenuPointer, applyMenuPointer);
+
+// Create variable that will temporarily hold title of new Todo list item
+char newItemTitle[GEM_STR_LEN];
+
+// Create menu item for title of new Todo list item
+void editTitle(); // Forward declaration
+GEMItem menuItemTitle("Title:", newItemTitle, editTitle);
+
+// Create menu button that will trigger addItem() function. It will add new record to Todo list.
+// We will write (define) this function later. However, we should
+// forward-declare it in order to pass to GEMItem constructor
+void addItem(); // Forward declaration
+GEMItem menuItemButtonAdd("Add", addItem);
+
+// Create menu button that will trigger clearItems() function. It will remove completed items from Todo list.
+// We will write (define) this function later. However, we should
+// forward-declare it in order to pass to GEMItem constructor
+void clearCompleted(); // Forward declaration
+GEMItem menuItemButtonClear("Clear completed", clearCompleted);
+
+// Create menu button that will trigger clearAll() function. It will remove all items from Todo list.
+// We will write (define) this function later. However, we should
+// forward-declare it in order to pass to GEMItem constructor
+void clearAll(); // Forward declaration
+GEMItem menuItemButtonClearAll("Clear all", clearAll);
+
+// Create menu page object of class GEMPage. Menu page holds menu items (GEMItem) and represents menu level.
+// Menu can have multiple menu pages (linked to each other) with multiple menu items each
+GEMPage menuPageMain("Main Menu"); // Main page
+GEMPage menuPageList("Todo", menuPageMain); // Todo list submenu
+GEMPage menuPageAdd("Add Item", menuPageList); // Add item submenu
+GEMPage menuPageManage("Manage", menuPageMain); // Manage submenu
+GEMPage menuPageSettings("Settings", menuPageMain); // Settings submenu
+
+// Create menu item links to submenu pages
+GEMItem menuItemLinkList("List", menuPageList); // Create menu item linked to List menu page
+GEMItem menuItemLinkAdd("Add+", menuPageAdd); // Create menu item linked to Add menu page
+GEMItem menuItemLinkManage("Manage", menuPageManage); // Create menu item linked to Manage menu page
+GEMItem menuItemLinkSettings("Settings", menuPageSettings); // Create menu item linked to Settings menu page
+
+// Create GEMAppearance objects
+GEMAppearance appearanceGeneral = { /* menuPointerType= */ menuPointer, /* menuItemsPerScreen= */ GEM_ITEMS_COUNT_AUTO, /* menuItemHeight= */ 10, /* menuPageScreenTopOffset= */ 10, /* menuValuesLeftOffset= */ 86};
+GEMAppearance appearanceList = appearanceGeneral;
+GEMAppearance appearanceAdd = appearanceGeneral;
+
+// Create menu object of class GEM_adafruit_gfx. Supply its constructor with reference to display object we created earlier
+GEM_adafruit_gfx menu(display, appearanceGeneral);
+
+void setup() {
+  // Pin modes
+  pinMode(channelA, INPUT_PULLUP);
+  pinMode(channelB, INPUT_PULLUP);
+  pinMode(buttonPin, INPUT_PULLUP);
+
+  // Serial communication setup
+  Serial.begin(115200);
+
+  // Show image buffer on the display hardware.
+  // Since the buffer is intialized with an Adafruit splashscreen
+  // internally, this will display the splashscreen.
+  delay(250);                       // Wait for the OLED to power up
+  display.begin(i2c_Address, true); // Address 0x3C default
+  
+  display.display();
+  delay(2000);
+
+  // Clear the buffer
+  display.clearDisplay();
+
+  // Explicitly set correct colors for monochrome OLED screen
+  menu
+    .setForegroundColor(SH110X_WHITE)
+    .setBackgroundColor(SH110X_BLACK);
+
+  menu
+    // Turn inverted order of characters during edit mode on (feels more natural when using encoder)
+    .invertKeysDuringEdit(invert)
+    // Disable GEM splash (it won't be visible on the screen of buffer-equiped displays such as this one any way)
+    .setSplashDelay(0)
+    // Menu init, setup and draw
+    .init();
+  setupMenu();
+
+  calculateFreeRam();
+  if (freeRam < 0) {
+    // Hide RAM counter if not available or rolled over an int value
+    menuItemRam.hide();
+  }
+
+  menu.drawMenu();
+
+  display.display();
+
+  Serial.println(F("Initialized"));
+}
+
+void setupMenu() {
+  // Add menu items to menu page
+  menuPageMain
+    .addMenuItem(menuItemLinkList)
+    .addMenuItem(menuItemLinkManage)
+    .addMenuItem(menuItemLinkSettings);
+
+  appearanceList.menuValuesLeftOffset = 118;
+
+  // Add menu items to List menu page
+  menuPageList
+    .setAppearance(&appearanceList)
+    .addMenuItem(menuItemLinkAdd);
+  
+  // Turn on adjusted order of ASCII characters when editing title
+  menuItemTitle.setAdjustedASCIIOrder();
+  
+  appearanceAdd.menuValuesLeftOffset = 46;
+  
+  // Add menu items to Add menu page
+  menuPageAdd
+    .setAppearance(&appearanceAdd)
+    .addMenuItem(menuItemTitle)
+    .addMenuItem(menuItemButtonAdd);
+  
+  // Add menu items to Manage menu page
+  menuPageManage
+    .addMenuItem(menuItemRam)
+    .addMenuItem(menuItemButtonClear)
+    .addMenuItem(menuItemButtonClearAll);
+ 
+  // Add menu items to Settings menu page
+  menuPageSettings
+    .addMenuItem(menuItemInvert)
+    .addMenuItem(menuItemMenuPointer);
+
+  // Set List page as a starting one
+  menu.setMenuPageCurrent(menuPageList);
+
+  // Hide Add button by default (until Todo item title is entered)
+  menuItemButtonAdd.hide();
+}
+
+// loop() is primarily used to manage rotary encoder operation,
+// with six push-buttons instead it is much shorter
+void loop() {
+  // Get current time to use later on
+  now = millis();
+
+  // If menu is ready to accept button press...
+  if (menu.readyForKey()) {
+    // ...detect key press using KeyDetector library
+    // and pass pressed button to menu
+    myKeyDetector.detect();
+
+    // Calculate RAM each loop iteration
+    calculateFreeRam();
+  
+    switch (myKeyDetector.trigger) {
+      case KEY_C:
+        // Button was pressed
+        // Save current time as a time of the key press event
+        keyPressTime = now;
+        break;
+    }
+    /* Detecting rotation of the encoder on release rather than push
+    (i.e. myKeyDetector.triggerRelease rather myKeyDetector.trigger)
+    may lead to more stable readings (without excessive signal ripple) */
+    switch (myKeyDetector.triggerRelease) {
+      case KEY_A:
+        // Signal from Channel A of encoder was detected
+        if (digitalRead(channelB) == LOW) {
+          // If channel B is low then the knob was rotated CCW
+          if (myKeyDetector.current == KEY_C) {
+            // If push-button was pressed at that time, then treat this action as GEM_KEY_LEFT,...
+            menu.registerKeyPress(GEM_KEY_LEFT);
+            // Button was in a pressed state during rotation of the knob, acting as a modifier to rotation action
+            secondaryPressed = true;
+          } else {
+            // ...or GEM_KEY_UP otherwise
+            menu.registerKeyPress(GEM_KEY_UP);
+          }
+        } else {
+          // If channel B is high then the knob was rotated CW
+          if (myKeyDetector.current == KEY_C) {
+            // If push-button was pressed at that time, then treat this action as GEM_KEY_RIGHT,...
+            menu.registerKeyPress(GEM_KEY_RIGHT);
+            // Button was in a pressed state during rotation of the knob, acting as a modifier to rotation action
+            secondaryPressed = true;
+          } else {
+            // ...or GEM_KEY_DOWN otherwise
+            menu.registerKeyPress(GEM_KEY_DOWN);
+          }
+        }
+        break;
+      case KEY_C:
+        // Button was released
+        if (!secondaryPressed) {
+          // If button was not used as a modifier to rotation action...
+          if (now <= keyPressTime + keyPressDelay) {
+            // ...and if not enough time passed since keyPressTime,
+            // treat key that was pressed as Ok button
+            menu.registerKeyPress(GEM_KEY_OK);
+          }
+        }
+        secondaryPressed = false;
+        cancelPressed = false;
+        break;
+    }
+    // After keyPressDelay passed since keyPressTime
+    if (now > keyPressTime + keyPressDelay) {
+      switch (myKeyDetector.current) {
+        case KEY_C:
+          if (!secondaryPressed && !cancelPressed) {
+            // If button was not used as a modifier to rotation action, and Cancel action was not triggered yet
+            // Treat key that was pressed as Cancel button
+            menu.registerKeyPress(GEM_KEY_CANCEL);
+            cancelPressed = true;
+          }
+          break;
+      }
+    }
+
+    // Necessary to actually draw current state of the menu on screen of buffer-equiped display with Adafruit GFX library
+    display.display();
+  }
+}
+
+void flashButtonTitle(const char* title, bool redraw = true) {
+  GEMItem* menuItemButtonTmp = menu.getCurrentMenuPage()->getCurrentMenuItem();
+  const char* titleOrig = menuItemButtonTmp->getTitle();
+  menuItemButtonTmp->setTitle(title);
+  menu.drawMenu();
+  display.display();
+  delay(1000);
+  menuItemButtonTmp->setTitle(titleOrig);
+  if (redraw) {
+    menu.drawMenu();
+    display.display();
+  }
+}
+
+void applyInvert() {
+  menu.invertKeysDuringEdit(invert);
+
+  // Print invert variable to Serial
+  Serial.print(F("Invert: "));
+  Serial.println(invert);
+}
+
+void applyMenuPointer() {
+  appearanceGeneral.menuPointerType = menuPointer;
+  menu.setAppearance(appearanceGeneral); // Need to call setAppearance() when changing general appearance
+  appearanceList.menuPointerType = menuPointer; // No need to call setAppearance() when changing apperance of menu pages, because it submitted as a pointer
+  appearanceAdd.menuPointerType = menuPointer;
+
+  // Print invert variable to Serial
+  Serial.print(F("Menu pointer: "));
+  Serial.println(menuPointer);
+}
+
+void editTitle() {
+  menuItemButtonAdd.hide(newItemTitle[0] == '\0');
+}
+
+void addItem() {
+  if (newItemTitle[0] != '\0') {
+    Serial.print(F("Add Item: "));
+    Serial.println(newItemTitle);
+    
+    // Creating new TodoItem object and adding corresponding menu item to menu page
+    menuItemLinkAdd.hide(); // Temporarily hide Add button to add new item at the end of the list (but before hidden button)
+    TodoItem* tempItem = new TodoItem(newItemTitle);
+    tempItem->menuItem->setCallbackVal(tempItem); // Save pointer to Todo item in a GEMCallbackData struct inside corresponding menu item
+    menuPageList.addMenuItem(*tempItem->menuItem, GEM_LAST_POS, GEM_ITEMS_VISIBLE);
+    menuItemLinkAdd.show();
+    memset(newItemTitle, '\0', GEM_STR_LEN - 1);
+
+    // Temporarily change title of Add button, but w/o redrawing menu (because we will hide it)
+    flashButtonTitle("Item added!", false);
+
+    menuItemButtonAdd.hide();
+  }
+  calculateFreeRam();
+  menu.drawMenu();
+  display.display();
+}
+
+void clearItems(bool onlyCompleted = true) {
+  GEMItem* menuItemTmp = menuPageList.getMenuItem(1); // Get first Todo item in a list to start traversing through menu items
+  Serial.println(F("Clearing items:"));
+  while (menuItemTmp->getLinkedVariablePointer() != nullptr) {
+    GEMItem* nextItem = menuItemTmp->getMenuItemNext(); // Save pointer to a next item
+    bool completed = *(bool*)menuItemTmp->getLinkedVariablePointer(); // Save completed status
+    if (completed || !onlyCompleted) {
+      // If linked boolean variable is true, then consider Todo item completed and ready to be removed 
+      // (and remove it anyway in case if onlyCompleted set to false)
+      Serial.print(completed ? "[x]" : "[ ]");
+      Serial.println(menuItemTmp->getTitle());
+      TodoItem* todoItemTmp = (TodoItem*)menuItemTmp->getCallbackData().valPointer; // Get pointer to corresponsing TodoItem object
+      menuItemTmp->remove(); // Remove menu item from menu page
+      delete menuItemTmp; // Delete GEMItem object
+      delete todoItemTmp; // Delete TodoItem object
+      /*
+        Note 1: sometimes (e.g. on ARM-based MCUs, but not on AVR or ESP32) deleting completed Todo items
+        doesn't immediately reflect on the amount of free RAM (as reported by getFreeRam()), however
+        if new Todo item is created afterwards (after deleting completed one) free RAM counter won't change.
+        That shows that deleteing objects is actually works (just not always reflected on the visible amount of free RAM,
+        probably for reasons discussed here: https://forum.arduino.cc/t/memory-no-getting-cleaned-up-after-delete/894404),
+        and new item presumably occupies previously freed memory. This may be related to so-called "buried heap space".
+        Note 2: amount of displayed free RAM may change after moving cursor from button after clearing, for the same amount every
+        time for some reason, even if no actual Todo items was deleted (it may something to do with processes needed to redraw
+        menu and/or stack allocation for clearItems() call). However, previous statement (Note 1) still holds.
+      */
+    }
+    menuItemTmp = nextItem;
+  }
+  calculateFreeRam();
+  menu.drawMenu();
+}
+
+void clearCompleted() {
+  clearItems();
+  flashButtonTitle("Cleared!");
+}
+
+void clearAll() {
+  clearItems(false);
+  flashButtonTitle("Cleared!");
+}

--- a/examples/AltSerialGraphicLCD/Example-06_Todo-List/Example-06_Todo-List.ino
+++ b/examples/AltSerialGraphicLCD/Example-06_Todo-List/Example-06_Todo-List.ino
@@ -1,0 +1,485 @@
+/*
+  Using GEM to create Todo list utilizing (god-forbidden) dynamic memory allocation (`new` and `delete`).
+  Using rotary encoder as an input source. Todo items can be dynamically added to the list,
+  marked completed and cleared (removed from the list). Additional settings are provided
+  (e.g. changing menu pointer style and order of characters in edit mode).
+
+  Note, that generally it is not recommended to implement dynamic memory allocation in microcontroller-based
+  projects for a number of reasons (mostly due to memory limitations and lack of supervisory OS to handle
+  memory management). Consider this example as an experiment and merely demonstration of some of the GEM
+  features, rather than a guide on how to manage dynamic memory in your project.
+
+  AltSerialGraphicLCD library is used to draw menu.
+  KeyDetector library (version 1.2.0 or later) is used to detect rotary encoder operation.
+
+  Points of improvement to consider:
+  - Prevent adding new Todo items if insufficient amount of RAM is available
+  - Add button to Uncheck all and/or Check all Todo items
+  - Use external storage (e.g. SD Card) to store data
+  - Make portable by adding battery
+  
+  This example uses the same schematics/breadboard as Example-05_Encoder (supplied with GEM).
+
+  Additional info (including the breadboard view) available on GitHub:
+  https://github.com/Spirik/GEM
+  
+  This example code is in the public domain.
+*/
+
+#include <GEM.h>
+#include <KeyDetector.h>
+
+//====================== CLASSES
+
+// Class representing Todo item
+class TodoItem {
+  public:
+    /* 
+      @param 'title_' - title of Todo item
+    */
+    TodoItem(char* title_){
+      strcpy(title, title_);
+      menuItem = new GEMItem(title, completed);
+    };
+
+    char title[GEM_STR_LEN];      // Title of Todo item
+    bool completed = false;       // Checkbox status
+    GEMItem* menuItem = nullptr;  // Pointer to corresponding menu item
+};
+
+//====================== MISC
+
+// Custom splash
+static const uint8_t splashBits [] PROGMEM = {
+  27, 8,
+  0x01, 0x01, 0x7d, 0x01, 0x01, 0x00, 0x00, 0x3e, 0x41, 0x41, 0x41, 0x3e, 0x00, 0x00, 0x7d, 0x41, 
+	0x41, 0x41, 0x3e, 0x00, 0x00, 0x3e, 0x41, 0x41, 0x41, 0x3e, 0x00
+};
+
+//====================== WORKING WITH ENCODER
+
+// Define signal identifiers for three outputs of encoder (channel A, channel B and a push-button)
+#define KEY_A 1
+#define KEY_B 2
+#define KEY_C 3
+
+// Pins encoder is connected to
+const byte channelA = 2;
+const byte channelB = 3;
+const byte buttonPin = 4;
+
+// Array of Key objects that will link GEM key identifiers with dedicated pins
+// (it is only necessary to detect signal change on a single channel of the encoder, either A or B;
+// order of the channel and push-button Key objects in an array is not important)
+Key keys[] = {{KEY_A, channelA}, {KEY_C, buttonPin}};
+
+// Create KeyDetector object
+// KeyDetector myKeyDetector(keys, sizeof(keys)/sizeof(Key));
+// To account for switch bounce effect of the buttons (if occur) you may want to specify debounceDelay
+// as the third argument to KeyDetector constructor.
+// Make sure to adjust debounce delay to better fit your rotary encoder.
+// Also it is possible to enable pull-up mode when buttons wired with pull-up resistors (as in this case).
+// Analog threshold is not necessary for this example and is set to default value 16.
+KeyDetector myKeyDetector(keys, sizeof(keys)/sizeof(Key), /* debounceDelay= */ 10, /* analogThreshold= */ 16, /* pullup= */ true);
+
+bool secondaryPressed = false;  // If encoder rotated while key was being pressed; used to prevent unwanted triggers
+bool cancelPressed = false;  // Flag indicating that Cancel action was triggered, used to prevent it from triggering multiple times
+const int keyPressDelay = 1000; // How long to hold key in pressed state to trigger Cancel action, ms
+long keyPressTime = 0; // Variable to hold time of the key press event
+long now; // Variable to hold current time taken with millis() function at the beginning of loop()
+
+//====================== OBTAINING RAM STATUS
+
+// Variable to store free RAM. It is an int, so overflows and rollover may occur, in that case, free RAM won't be displayed
+int freeRam;
+GEMItem menuItemRam("Free RAM:", freeRam, GEM_READONLY); // Menu item associated with it
+
+// Free RAM calculations
+// (based on https://docs.arduino.cc/learn/programming/memory-guide and https://github.com/mpflaga/Arduino-MemoryFree/)
+#if defined(__arm__) && !defined(ARDUINO_ARCH_RP2040)
+// ARM (except RP2040, which won't display correct values, probably due to internal implementation)
+
+extern "C" char* sbrk(int incr);
+
+void calculateFreeRam() {
+  freeRam = getFreeRam();
+}
+
+int getFreeRam() {
+  char top;
+  return &top - reinterpret_cast<char*>(sbrk(0));
+}
+
+#elif defined(ARDUINO_ARCH_AVR)
+// ARM
+
+void calculateFreeRam() {
+  freeRam = getFreeRam();
+}
+
+int getFreeRam() {
+  extern int __heap_start,*__brkval;
+  int v;
+  return (int)&v - (__brkval == 0 ? (int)&__heap_start : (int) __brkval);
+}
+
+#elif defined(ARDUINO_ARCH_ESP32)
+// ESP32
+
+void calculateFreeRam() {
+  freeRam = ESP.getFreeHeap();
+}
+
+#else
+// Correct detection of free RAM not implemented
+
+void calculateFreeRam() {
+  freeRam = -1;
+}
+
+#endif
+
+//====================== DISPLAY
+
+// Constants for the pins SparkFun Graphic LCD Serial Backpack is connected to and SoftwareSerial object
+const byte rxPin = 8;
+const byte txPin = 9;
+SoftwareSerial serialLCD(rxPin, txPin);
+
+// Create an instance of the GLCD class. This instance is used to call all the subsequent GLCD functions
+// (internally from GEM library, or manually in your sketch if it is required)
+GLCD glcd(serialLCD);
+
+//====================== MENU AND CORRESPONDING ELEMENTS
+
+// Create variable that will be editable through option select and create associated option select.
+// This variable will be passed to menu.invertKeysDuringEdit(), and naturally can be presented as a boolean,
+// but is declared as a byte type to be used in an option select rather than checkbox (for demonstration purposes)
+byte invert = 1;
+SelectOptionByte selectInvertOptions[] = {{"Invert", 1}, {"Normal", 0}};
+GEMSelect selectInvert(sizeof(selectInvertOptions)/sizeof(SelectOptionByte), selectInvertOptions);
+
+// Create menu item for option select with applyInvert() callback function
+void applyInvert(); // Forward declaration
+GEMItem menuItemInvert("Chars order:", invert, selectInvert, applyInvert);
+
+// Create variable holding appearance of menu pointer that will be editable through option select and create associated option select.
+byte menuPointer = GEM_POINTER_ROW;
+SelectOptionByte selectMenuPointerOptions[] = {{"Row", GEM_POINTER_ROW}, {"Dash", GEM_POINTER_DASH}};
+GEMSelect selectMenuPointer(sizeof(selectMenuPointerOptions)/sizeof(SelectOptionByte), selectMenuPointerOptions);
+
+// Create menu item for option select with applyMenuPointer() callback function
+void applyMenuPointer(); // Forward declaration
+GEMItem menuItemMenuPointer("Menu pointer:", menuPointer, selectMenuPointer, applyMenuPointer);
+
+// Create variable that will temporarily hold title of new Todo list item
+char newItemTitle[GEM_STR_LEN];
+
+// Create menu item for title of new Todo list item
+void editTitle(); // Forward declaration
+GEMItem menuItemTitle("Title:", newItemTitle, editTitle);
+
+// Create menu button that will trigger addItem() function. It will add new record to Todo list.
+// We will write (define) this function later. However, we should
+// forward-declare it in order to pass to GEMItem constructor
+void addItem(); // Forward declaration
+GEMItem menuItemButtonAdd("Add", addItem);
+
+// Create menu button that will trigger clearItems() function. It will remove completed items from Todo list.
+// We will write (define) this function later. However, we should
+// forward-declare it in order to pass to GEMItem constructor
+void clearCompleted(); // Forward declaration
+GEMItem menuItemButtonClear("Clear completed", clearCompleted);
+
+// Create menu button that will trigger clearAll() function. It will remove all items from Todo list.
+// We will write (define) this function later. However, we should
+// forward-declare it in order to pass to GEMItem constructor
+void clearAll(); // Forward declaration
+GEMItem menuItemButtonClearAll("Clear all", clearAll);
+
+// Create menu page object of class GEMPage. Menu page holds menu items (GEMItem) and represents menu level.
+// Menu can have multiple menu pages (linked to each other) with multiple menu items each
+GEMPage menuPageMain("Main Menu"); // Main page
+GEMPage menuPageList("Todo", menuPageMain); // Todo list submenu
+GEMPage menuPageAdd("Add Item", menuPageList); // Add item submenu
+GEMPage menuPageManage("Manage", menuPageMain); // Manage submenu
+GEMPage menuPageSettings("Settings", menuPageMain); // Settings submenu
+
+// Create menu item links to submenu pages
+GEMItem menuItemLinkList("List", menuPageList); // Create menu item linked to List menu page
+GEMItem menuItemLinkAdd("Add+", menuPageAdd); // Create menu item linked to Add menu page
+GEMItem menuItemLinkManage("Manage", menuPageManage); // Create menu item linked to Manage menu page
+GEMItem menuItemLinkSettings("Settings", menuPageSettings); // Create menu item linked to Settings menu page
+
+// Create GEMAppearance objects
+GEMAppearance appearanceGeneral = { /* menuPointerType= */ menuPointer, /* menuItemsPerScreen= */ GEM_ITEMS_COUNT_AUTO, /* menuItemHeight= */ 10, /* menuPageScreenTopOffset= */ 10, /* menuValuesLeftOffset= */ 86};
+GEMAppearance appearanceList = appearanceGeneral;
+GEMAppearance appearanceAdd = appearanceGeneral;
+
+// Create menu object of class GEM. Supply its constructor with reference to glcd object we created earlier
+GEM menu(glcd, appearanceGeneral);
+
+void setup() {
+  // Pin modes
+  pinMode(channelA, INPUT_PULLUP);
+  pinMode(channelB, INPUT_PULLUP);
+  pinMode(buttonPin, INPUT_PULLUP);
+
+  // Serial communication setup
+  Serial.begin(115200);
+  serialLCD.begin(115200);
+
+  // LCD reset
+  delay(500);
+  glcd.reset();
+  delay(1000);
+  // Uncomment the following lines in dire situations
+  // (e.g. when screen becomes unresponsive after shutdown)
+  glcd.reset();
+  delay(1000);
+
+  menu
+    // Turn inverted order of characters during edit mode on (feels more natural when using encoder)
+    .invertKeysDuringEdit(invert)
+    // Set custom splash
+    .setSplash(splashBits)
+    // Menu init, setup and draw
+    .init();
+  setupMenu();
+
+  calculateFreeRam();
+  if (freeRam < 0) {
+    // Hide RAM counter if not available or rolled over an int value
+    menuItemRam.hide();
+  }
+
+  menu.drawMenu();
+
+  Serial.println(F("Initialized"));
+}
+
+void setupMenu() {
+  // Add menu items to menu page
+  menuPageMain
+    .addMenuItem(menuItemLinkList)
+    .addMenuItem(menuItemLinkManage)
+    .addMenuItem(menuItemLinkSettings);
+
+  appearanceList.menuValuesLeftOffset = 118;
+
+  // Add menu items to List menu page
+  menuPageList
+    .setAppearance(&appearanceList)
+    .addMenuItem(menuItemLinkAdd);
+  
+  // Turn on adjusted order of ASCII characters when editing title
+  menuItemTitle.setAdjustedASCIIOrder();
+  
+  appearanceAdd.menuValuesLeftOffset = 46;
+  
+  // Add menu items to Add menu page
+  menuPageAdd
+    .setAppearance(&appearanceAdd)
+    .addMenuItem(menuItemTitle)
+    .addMenuItem(menuItemButtonAdd);
+  
+  // Add menu items to Manage menu page
+  menuPageManage
+    .addMenuItem(menuItemRam)
+    .addMenuItem(menuItemButtonClear)
+    .addMenuItem(menuItemButtonClearAll);
+ 
+  // Add menu items to Settings menu page
+  menuPageSettings
+    .addMenuItem(menuItemInvert)
+    .addMenuItem(menuItemMenuPointer);
+
+  // Set List page as a starting one
+  menu.setMenuPageCurrent(menuPageList);
+
+  // Hide Add button by default (until Todo item title is entered)
+  menuItemButtonAdd.hide();
+}
+
+// loop() is primarily used to manage rotary encoder operation,
+// with six push-buttons instead it is much shorter
+void loop() {
+  // Get current time to use later on
+  now = millis();
+
+  // If menu is ready to accept button press...
+  if (menu.readyForKey()) {
+    // ...detect key press using KeyDetector library
+    // and pass pressed button to menu
+    myKeyDetector.detect();
+
+    // Calculate RAM each loop iteration
+    calculateFreeRam();
+  
+    switch (myKeyDetector.trigger) {
+      case KEY_C:
+        // Button was pressed
+        // Save current time as a time of the key press event
+        keyPressTime = now;
+        break;
+    }
+    /* Detecting rotation of the encoder on release rather than push
+    (i.e. myKeyDetector.triggerRelease rather myKeyDetector.trigger)
+    may lead to more stable readings (without excessive signal ripple) */
+    switch (myKeyDetector.triggerRelease) {
+      case KEY_A:
+        // Signal from Channel A of encoder was detected
+        if (digitalRead(channelB) == LOW) {
+          // If channel B is low then the knob was rotated CCW
+          if (myKeyDetector.current == KEY_C) {
+            // If push-button was pressed at that time, then treat this action as GEM_KEY_LEFT,...
+            menu.registerKeyPress(GEM_KEY_LEFT);
+            // Button was in a pressed state during rotation of the knob, acting as a modifier to rotation action
+            secondaryPressed = true;
+          } else {
+            // ...or GEM_KEY_UP otherwise
+            menu.registerKeyPress(GEM_KEY_UP);
+          }
+        } else {
+          // If channel B is high then the knob was rotated CW
+          if (myKeyDetector.current == KEY_C) {
+            // If push-button was pressed at that time, then treat this action as GEM_KEY_RIGHT,...
+            menu.registerKeyPress(GEM_KEY_RIGHT);
+            // Button was in a pressed state during rotation of the knob, acting as a modifier to rotation action
+            secondaryPressed = true;
+          } else {
+            // ...or GEM_KEY_DOWN otherwise
+            menu.registerKeyPress(GEM_KEY_DOWN);
+          }
+        }
+        break;
+      case KEY_C:
+        // Button was released
+        if (!secondaryPressed) {
+          // If button was not used as a modifier to rotation action...
+          if (now <= keyPressTime + keyPressDelay) {
+            // ...and if not enough time passed since keyPressTime,
+            // treat key that was pressed as Ok button
+            menu.registerKeyPress(GEM_KEY_OK);
+          }
+        }
+        secondaryPressed = false;
+        cancelPressed = false;
+        break;
+    }
+    // After keyPressDelay passed since keyPressTime
+    if (now > keyPressTime + keyPressDelay) {
+      switch (myKeyDetector.current) {
+        case KEY_C:
+          if (!secondaryPressed && !cancelPressed) {
+            // If button was not used as a modifier to rotation action, and Cancel action was not triggered yet
+            // Treat key that was pressed as Cancel button
+            menu.registerKeyPress(GEM_KEY_CANCEL);
+            cancelPressed = true;
+          }
+          break;
+      }
+    }
+  }
+}
+
+
+void flashButtonTitle(const char* title, bool redraw = true) {
+  GEMItem* menuItemButtonTmp = menu.getCurrentMenuPage()->getCurrentMenuItem();
+  const char* titleOrig = menuItemButtonTmp->getTitle();
+  menuItemButtonTmp->setTitle(title);
+  menu.drawMenu();
+  delay(1000);
+  menuItemButtonTmp->setTitle(titleOrig);
+  if (redraw) {
+    menu.drawMenu();
+  }
+}
+
+void applyInvert() {
+  menu.invertKeysDuringEdit(invert);
+
+  // Print invert variable to Serial
+  Serial.print(F("Invert: "));
+  Serial.println(invert);
+}
+
+void applyMenuPointer() {
+  appearanceGeneral.menuPointerType = menuPointer;
+  menu.setAppearance(appearanceGeneral); // Need to call setAppearance() when changing general appearance
+  appearanceList.menuPointerType = menuPointer; // No need to call setAppearance() when changing apperance of menu pages, because it submitted as a pointer
+  appearanceAdd.menuPointerType = menuPointer;
+
+  // Print invert variable to Serial
+  Serial.print(F("Menu pointer: "));
+  Serial.println(menuPointer);
+}
+
+void editTitle() {
+  menuItemButtonAdd.hide(newItemTitle[0] == '\0');
+}
+
+void addItem() {
+  if (newItemTitle[0] != '\0') {
+    Serial.print(F("Add Item: "));
+    Serial.println(newItemTitle);
+    
+    // Creating new TodoItem object and adding corresponding menu item to menu page
+    menuItemLinkAdd.hide(); // Temporarily hide Add button to add new item at the end of the list (but before hidden button)
+    TodoItem* tempItem = new TodoItem(newItemTitle);
+    tempItem->menuItem->setCallbackVal(tempItem); // Save pointer to Todo item in a GEMCallbackData struct inside corresponding menu item
+    menuPageList.addMenuItem(*tempItem->menuItem, GEM_LAST_POS, GEM_ITEMS_VISIBLE);
+    menuItemLinkAdd.show();
+    memset(newItemTitle, '\0', GEM_STR_LEN - 1);
+
+    // Temporarily change title of Add button, but w/o redrawing menu (because we will hide it)
+    flashButtonTitle("Item added!", false);
+
+    menuItemButtonAdd.hide();
+  }
+  calculateFreeRam();
+  menu.drawMenu();
+}
+
+void clearItems(bool onlyCompleted = true) {
+  GEMItem* menuItemTmp = menuPageList.getMenuItem(1); // Get first Todo item in a list to start traversing through menu items
+  Serial.println(F("Clearing items:"));
+  while (menuItemTmp->getLinkedVariablePointer() != nullptr) {
+    GEMItem* nextItem = menuItemTmp->getMenuItemNext(); // Save pointer to a next item
+    bool completed = *(bool*)menuItemTmp->getLinkedVariablePointer(); // Save completed status
+    if (completed || !onlyCompleted) {
+      // If linked boolean variable is true, then consider Todo item completed and ready to be removed 
+      // (and remove it anyway in case if onlyCompleted set to false)
+      Serial.print(completed ? "[x]" : "[ ]");
+      Serial.println(menuItemTmp->getTitle());
+      TodoItem* todoItemTmp = (TodoItem*)menuItemTmp->getCallbackData().valPointer; // Get pointer to corresponsing TodoItem object
+      menuItemTmp->remove(); // Remove menu item from menu page
+      delete menuItemTmp; // Delete GEMItem object
+      delete todoItemTmp; // Delete TodoItem object
+      /*
+        Note 1: sometimes (e.g. on ARM-based MCUs, but not on AVR or ESP32) deleting completed Todo items
+        doesn't immediately reflect on the amount of free RAM (as reported by getFreeRam()), however
+        if new Todo item is created afterwards (after deleting completed one) free RAM counter won't change.
+        That shows that deleteing objects is actually works (just not always reflected on the visible amount of free RAM,
+        probably for reasons discussed here: https://forum.arduino.cc/t/memory-no-getting-cleaned-up-after-delete/894404),
+        and new item presumably occupies previously freed memory. This may be related to so-called "buried heap space".
+        Note 2: amount of displayed free RAM may change after moving cursor from button after clearing, for the same amount every
+        time for some reason, even if no actual Todo items was deleted (it may something to do with processes needed to redraw
+        menu and/or stack allocation for clearItems() call). However, previous statement (Note 1) still holds.
+      */
+    }
+    menuItemTmp = nextItem;
+  }
+  calculateFreeRam();
+  menu.drawMenu();
+}
+
+void clearCompleted() {
+  clearItems();
+  flashButtonTitle("Cleared!");
+}
+
+void clearAll() {
+  clearItems(false);
+  flashButtonTitle("Cleared!");
+}

--- a/examples/U8g2/Example-06_Todo-List/Example-06_Todo-List.ino
+++ b/examples/U8g2/Example-06_Todo-List/Example-06_Todo-List.ino
@@ -1,0 +1,478 @@
+/*
+  Using GEM to create Todo list utilizing (god-forbidden) dynamic memory allocation (`new` and `delete`).
+  Using rotary encoder as an input source. Todo items can be dynamically added to the list,
+  marked completed and cleared (removed from the list). Additional settings are provided
+  (e.g. changing menu pointer style and order of characters in edit mode).
+
+  Note, that generally it is not recommended to implement dynamic memory allocation in microcontroller-based
+  projects for a number of reasons (mostly due to memory limitations and lack of supervisory OS to handle
+  memory management). Consider this example as an experiment and merely demonstration of some of the GEM
+  features, rather than a guide on how to manage dynamic memory in your project.
+
+  U8g2lib library is used to draw menu.
+  KeyDetector library (version 1.2.0 or later) is used to detect rotary encoder operation.
+
+  Points of improvement to consider:
+  - Prevent adding new Todo items if insufficient amount of RAM is available
+  - Add button to Uncheck all and/or Check all Todo items
+  - Use external storage (e.g. SD Card) to store data
+  - Make portable by adding battery
+  
+  This example uses the same schematics/breadboard as Example-05_Encoder (supplied with GEM).
+
+  Additional info (including the breadboard view) available on GitHub:
+  https://github.com/Spirik/GEM
+  
+  This example code is in the public domain.
+*/
+
+#include <GEM_u8g2.h>
+#include <KeyDetector.h>
+
+//====================== CLASSES
+
+// Class representing Todo item
+class TodoItem {
+  public:
+    /* 
+      @param 'title_' - title of Todo item
+    */
+    TodoItem(char* title_){
+      strcpy(title, title_);
+      menuItem = new GEMItem(title, completed);
+    };
+
+    char title[GEM_STR_LEN];      // Title of Todo item
+    bool completed = false;       // Checkbox status
+    GEMItem* menuItem = nullptr;  // Pointer to corresponding menu item
+};
+
+//====================== MISC
+
+// Custom splash
+#define splashWidth  27
+#define splashHeight 8
+static const unsigned char splashBits [] U8X8_PROGMEM = {
+  0x1F, 0xC7, 0xC3, 0x01, 0x80, 0x08, 0x24, 0x02, 0x84, 0x48, 0x24, 0x02, 
+  0x84, 0x48, 0x24, 0x02, 0x84, 0x48, 0x24, 0x02, 0x84, 0x48, 0x24, 0x02, 
+  0x04, 0xC7, 0xC3, 0x01, 0x00, 0x00, 0x00, 0x00
+};
+
+//====================== WORKING WITH ENCODER
+
+// Define signal identifiers for three outputs of encoder (channel A, channel B and a push-button)
+#define KEY_A 1
+#define KEY_B 2
+#define KEY_C 3
+
+// Pins encoder is connected to
+const byte channelA = 2;
+const byte channelB = 3;
+const byte buttonPin = 4;
+
+// Array of Key objects that will link GEM key identifiers with dedicated pins
+// (it is only necessary to detect signal change on a single channel of the encoder, either A or B;
+// order of the channel and push-button Key objects in an array is not important)
+Key keys[] = {{KEY_A, channelA}, {KEY_C, buttonPin}};
+
+// Create KeyDetector object
+// KeyDetector myKeyDetector(keys, sizeof(keys)/sizeof(Key));
+// To account for switch bounce effect of the buttons (if occur) you may want to specify debounceDelay
+// as the third argument to KeyDetector constructor.
+// Make sure to adjust debounce delay to better fit your rotary encoder.
+// Also it is possible to enable pull-up mode when buttons wired with pull-up resistors (as in this case).
+// Analog threshold is not necessary for this example and is set to default value 16.
+KeyDetector myKeyDetector(keys, sizeof(keys)/sizeof(Key), /* debounceDelay= */ 10, /* analogThreshold= */ 16, /* pullup= */ true);
+
+bool secondaryPressed = false;  // If encoder rotated while key was being pressed; used to prevent unwanted triggers
+bool cancelPressed = false;  // Flag indicating that Cancel action was triggered, used to prevent it from triggering multiple times
+const int keyPressDelay = 1000; // How long to hold key in pressed state to trigger Cancel action, ms
+long keyPressTime = 0; // Variable to hold time of the key press event
+long now; // Variable to hold current time taken with millis() function at the beginning of loop()
+
+//====================== OBTAINING RAM STATUS
+
+// Variable to store free RAM. It is an int, so overflows and rollover may occur, in that case, free RAM won't be displayed
+int freeRam;
+GEMItem menuItemRam("Free RAM:", freeRam, GEM_READONLY); // Menu item associated with it
+
+// Free RAM calculations
+// (based on https://docs.arduino.cc/learn/programming/memory-guide and https://github.com/mpflaga/Arduino-MemoryFree/)
+#if defined(__arm__) && !defined(ARDUINO_ARCH_RP2040)
+// ARM (except RP2040, which won't display correct values, probably due to internal implementation)
+
+extern "C" char* sbrk(int incr);
+
+void calculateFreeRam() {
+  freeRam = getFreeRam();
+}
+
+int getFreeRam() {
+  char top;
+  return &top - reinterpret_cast<char*>(sbrk(0));
+}
+
+#elif defined(ARDUINO_ARCH_AVR)
+// ARM
+
+void calculateFreeRam() {
+  freeRam = getFreeRam();
+}
+
+int getFreeRam() {
+  extern int __heap_start,*__brkval;
+  int v;
+  return (int)&v - (__brkval == 0 ? (int)&__heap_start : (int) __brkval);
+}
+
+#elif defined(ARDUINO_ARCH_ESP32)
+// ESP32
+
+void calculateFreeRam() {
+  freeRam = ESP.getFreeHeap();
+}
+
+#else
+// Correct detection of free RAM not implemented
+
+void calculateFreeRam() {
+  freeRam = -1;
+}
+
+#endif
+
+//====================== DISPLAY
+
+// Create an instance of the U8g2 library.
+// Use constructor that matches your setup (see https://github.com/olikraus/u8g2/wiki/u8g2setupcpp for details).
+// This instance is used to call all the subsequent U8g2 functions (internally from GEM library,
+// or manually in your sketch if it is required).
+// Please update the pin numbers according to your setup. Use U8X8_PIN_NONE if the reset pin is not connected
+U8G2_SH1106_128X64_NONAME_1_HW_I2C u8g2(U8G2_R0, /* reset=*/ U8X8_PIN_NONE);
+
+//====================== MENU AND CORRESPONDING ELEMENTS
+
+// Create variable that will be editable through option select and create associated option select.
+// This variable will be passed to menu.invertKeysDuringEdit(), and naturally can be presented as a boolean,
+// but is declared as a byte type to be used in an option select rather than checkbox (for demonstration purposes)
+byte invert = 1;
+SelectOptionByte selectInvertOptions[] = {{"Invert", 1}, {"Normal", 0}};
+GEMSelect selectInvert(sizeof(selectInvertOptions)/sizeof(SelectOptionByte), selectInvertOptions);
+
+// Create menu item for option select with applyInvert() callback function
+void applyInvert(); // Forward declaration
+GEMItem menuItemInvert("Chars order:", invert, selectInvert, applyInvert);
+
+// Create variable holding appearance of menu pointer that will be editable through option select and create associated option select.
+byte menuPointer = GEM_POINTER_ROW;
+SelectOptionByte selectMenuPointerOptions[] = {{"Row", GEM_POINTER_ROW}, {"Dash", GEM_POINTER_DASH}};
+GEMSelect selectMenuPointer(sizeof(selectMenuPointerOptions)/sizeof(SelectOptionByte), selectMenuPointerOptions);
+
+// Create menu item for option select with applyMenuPointer() callback function
+void applyMenuPointer(); // Forward declaration
+GEMItem menuItemMenuPointer("Menu pointer:", menuPointer, selectMenuPointer, applyMenuPointer);
+
+// Create variable that will temporarily hold title of new Todo list item
+char newItemTitle[GEM_STR_LEN];
+
+// Create menu item for title of new Todo list item
+void editTitle(); // Forward declaration
+GEMItem menuItemTitle("Title:", newItemTitle, editTitle);
+
+// Create menu button that will trigger addItem() function. It will add new record to Todo list.
+// We will write (define) this function later. However, we should
+// forward-declare it in order to pass to GEMItem constructor
+void addItem(); // Forward declaration
+GEMItem menuItemButtonAdd("Add", addItem);
+
+// Create menu button that will trigger clearItems() function. It will remove completed items from Todo list.
+// We will write (define) this function later. However, we should
+// forward-declare it in order to pass to GEMItem constructor
+void clearCompleted(); // Forward declaration
+GEMItem menuItemButtonClear("Clear completed", clearCompleted);
+
+// Create menu button that will trigger clearAll() function. It will remove all items from Todo list.
+// We will write (define) this function later. However, we should
+// forward-declare it in order to pass to GEMItem constructor
+void clearAll(); // Forward declaration
+GEMItem menuItemButtonClearAll("Clear all", clearAll);
+
+// Create menu page object of class GEMPage. Menu page holds menu items (GEMItem) and represents menu level.
+// Menu can have multiple menu pages (linked to each other) with multiple menu items each
+GEMPage menuPageMain("Main Menu"); // Main page
+GEMPage menuPageList("Todo", menuPageMain); // Todo list submenu
+GEMPage menuPageAdd("Add Item", menuPageList); // Add item submenu
+GEMPage menuPageManage("Manage", menuPageMain); // Manage submenu
+GEMPage menuPageSettings("Settings", menuPageMain); // Settings submenu
+
+// Create menu item links to submenu pages
+GEMItem menuItemLinkList("List", menuPageList); // Create menu item linked to List menu page
+GEMItem menuItemLinkAdd("Add+", menuPageAdd); // Create menu item linked to Add menu page
+GEMItem menuItemLinkManage("Manage", menuPageManage); // Create menu item linked to Manage menu page
+GEMItem menuItemLinkSettings("Settings", menuPageSettings); // Create menu item linked to Settings menu page
+
+// Create GEMAppearance objects
+GEMAppearance appearanceGeneral = { /* menuPointerType= */ menuPointer, /* menuItemsPerScreen= */ GEM_ITEMS_COUNT_AUTO, /* menuItemHeight= */ 10, /* menuPageScreenTopOffset= */ 10, /* menuValuesLeftOffset= */ 86};
+GEMAppearance appearanceList = appearanceGeneral;
+GEMAppearance appearanceAdd = appearanceGeneral;
+
+// Create menu object of class GEM_u8g2. Supply its constructor with reference to u8g2 object we created earlier
+GEM_u8g2 menu(u8g2, appearanceGeneral);
+
+void setup() {
+  // Pin modes
+  pinMode(channelA, INPUT_PULLUP);
+  pinMode(channelB, INPUT_PULLUP);
+  pinMode(buttonPin, INPUT_PULLUP);
+
+  // Serial communication setup
+  Serial.begin(115200);
+
+  // U8g2 library init.
+  u8g2.begin();
+
+  menu
+    // Turn inverted order of characters during edit mode on (feels more natural when using encoder)
+    .invertKeysDuringEdit(invert)
+    // Set custom splash
+    .setSplash(splashWidth, splashHeight, splashBits)
+    // Menu init, setup and draw
+    .init();
+  setupMenu();
+
+  calculateFreeRam();
+  if (freeRam < 0) {
+    // Hide RAM counter if not available or rolled over an int value
+    menuItemRam.hide();
+  }
+
+  menu.drawMenu();
+
+  Serial.println(F("Initialized"));
+}
+
+void setupMenu() {
+  // Add menu items to menu page
+  menuPageMain
+    .addMenuItem(menuItemLinkList)
+    .addMenuItem(menuItemLinkManage)
+    .addMenuItem(menuItemLinkSettings);
+
+  appearanceList.menuValuesLeftOffset = 118;
+
+  // Add menu items to List menu page
+  menuPageList
+    .setAppearance(&appearanceList)
+    .addMenuItem(menuItemLinkAdd);
+  
+  // Turn on adjusted order of ASCII characters when editing title
+  menuItemTitle.setAdjustedASCIIOrder();
+  
+  appearanceAdd.menuValuesLeftOffset = 46;
+  
+  // Add menu items to Add menu page
+  menuPageAdd
+    .setAppearance(&appearanceAdd)
+    .addMenuItem(menuItemTitle)
+    .addMenuItem(menuItemButtonAdd);
+  
+  // Add menu items to Manage menu page
+  menuPageManage
+    .addMenuItem(menuItemRam)
+    .addMenuItem(menuItemButtonClear)
+    .addMenuItem(menuItemButtonClearAll);
+ 
+  // Add menu items to Settings menu page
+  menuPageSettings
+    .addMenuItem(menuItemInvert)
+    .addMenuItem(menuItemMenuPointer);
+
+  // Set List page as a starting one
+  menu.setMenuPageCurrent(menuPageList);
+
+  // Hide Add button by default (until Todo item title is entered)
+  menuItemButtonAdd.hide();
+}
+
+// loop() is primarily used to manage rotary encoder operation,
+// with six push-buttons instead it is much shorter
+void loop() {
+  // Get current time to use later on
+  now = millis();
+
+  // If menu is ready to accept button press...
+  if (menu.readyForKey()) {
+    // ...detect key press using KeyDetector library
+    // and pass pressed button to menu
+    myKeyDetector.detect();
+
+    // Calculate RAM each loop iteration
+    // calculateFreeRam();
+  
+    switch (myKeyDetector.trigger) {
+      case KEY_C:
+        // Button was pressed
+        // Save current time as a time of the key press event
+        keyPressTime = now;
+        break;
+    }
+    /* Detecting rotation of the encoder on release rather than push
+    (i.e. myKeyDetector.triggerRelease rather myKeyDetector.trigger)
+    may lead to more stable readings (without excessive signal ripple) */
+    switch (myKeyDetector.triggerRelease) {
+      case KEY_A:
+        // Signal from Channel A of encoder was detected
+        if (digitalRead(channelB) == LOW) {
+          // If channel B is low then the knob was rotated CCW
+          if (myKeyDetector.current == KEY_C) {
+            // If push-button was pressed at that time, then treat this action as GEM_KEY_LEFT,...
+            menu.registerKeyPress(GEM_KEY_LEFT);
+            // Button was in a pressed state during rotation of the knob, acting as a modifier to rotation action
+            secondaryPressed = true;
+          } else {
+            // ...or GEM_KEY_UP otherwise
+            menu.registerKeyPress(GEM_KEY_UP);
+          }
+        } else {
+          // If channel B is high then the knob was rotated CW
+          if (myKeyDetector.current == KEY_C) {
+            // If push-button was pressed at that time, then treat this action as GEM_KEY_RIGHT,...
+            menu.registerKeyPress(GEM_KEY_RIGHT);
+            // Button was in a pressed state during rotation of the knob, acting as a modifier to rotation action
+            secondaryPressed = true;
+          } else {
+            // ...or GEM_KEY_DOWN otherwise
+            menu.registerKeyPress(GEM_KEY_DOWN);
+          }
+        }
+        break;
+      case KEY_C:
+        // Button was released
+        if (!secondaryPressed) {
+          // If button was not used as a modifier to rotation action...
+          if (now <= keyPressTime + keyPressDelay) {
+            // ...and if not enough time passed since keyPressTime,
+            // treat key that was pressed as Ok button
+            menu.registerKeyPress(GEM_KEY_OK);
+          }
+        }
+        secondaryPressed = false;
+        cancelPressed = false;
+        break;
+    }
+    // After keyPressDelay passed since keyPressTime
+    if (now > keyPressTime + keyPressDelay) {
+      switch (myKeyDetector.current) {
+        case KEY_C:
+          if (!secondaryPressed && !cancelPressed) {
+            // If button was not used as a modifier to rotation action, and Cancel action was not triggered yet
+            // Treat key that was pressed as Cancel button
+            menu.registerKeyPress(GEM_KEY_CANCEL);
+            cancelPressed = true;
+          }
+          break;
+      }
+    }
+  }
+}
+
+
+void flashButtonTitle(const char* title, bool redraw = true) {
+  GEMItem* menuItemButtonTmp = menu.getCurrentMenuPage()->getCurrentMenuItem();
+  const char* titleOrig = menuItemButtonTmp->getTitle();
+  menuItemButtonTmp->setTitle(title);
+  menu.drawMenu();
+  delay(1000);
+  menuItemButtonTmp->setTitle(titleOrig);
+  if (redraw) {
+    menu.drawMenu();
+  }
+}
+
+void applyInvert() {
+  menu.invertKeysDuringEdit(invert);
+
+  // Print invert variable to Serial
+  Serial.print(F("Invert: "));
+  Serial.println(invert);
+}
+
+void applyMenuPointer() {
+  appearanceGeneral.menuPointerType = menuPointer;
+  menu.setAppearance(appearanceGeneral); // Need to call setAppearance() when changing general appearance
+  appearanceList.menuPointerType = menuPointer; // No need to call setAppearance() when changing apperance of menu pages, because it submitted as a pointer
+  appearanceAdd.menuPointerType = menuPointer;
+
+  // Print invert variable to Serial
+  Serial.print(F("Menu pointer: "));
+  Serial.println(menuPointer);
+}
+
+void editTitle() {
+  menuItemButtonAdd.hide(newItemTitle[0] == '\0');
+}
+
+void addItem() {
+  if (newItemTitle[0] != '\0') {
+    Serial.print(F("Add Item: "));
+    Serial.println(newItemTitle);
+    
+    // Creating new TodoItem object and adding corresponding menu item to menu page
+    menuItemLinkAdd.hide(); // Temporarily hide Add button to add new item at the end of the list (but before hidden button)
+    TodoItem* tempItem = new TodoItem(newItemTitle);
+    tempItem->menuItem->setCallbackVal(tempItem); // Save pointer to Todo item in a GEMCallbackData struct inside corresponding menu item
+    menuPageList.addMenuItem(*tempItem->menuItem, GEM_LAST_POS, GEM_ITEMS_VISIBLE);
+    menuItemLinkAdd.show();
+    memset(newItemTitle, '\0', GEM_STR_LEN - 1);
+
+    // Temporarily change title of Add button, but w/o redrawing menu (because we will hide it)
+    flashButtonTitle("Item added!", false);
+
+    menuItemButtonAdd.hide();
+  }
+  calculateFreeRam();
+  menu.drawMenu();
+}
+
+void clearItems(bool onlyCompleted = true) {
+  GEMItem* menuItemTmp = menuPageList.getMenuItem(1); // Get first Todo item in a list to start traversing through menu items
+  Serial.println(F("Clearing items:"));
+  while (menuItemTmp->getLinkedVariablePointer() != nullptr) {
+    GEMItem* nextItem = menuItemTmp->getMenuItemNext(); // Save pointer to a next item
+    bool completed = *(bool*)menuItemTmp->getLinkedVariablePointer(); // Save completed status
+    if (completed || !onlyCompleted) {
+      // If linked boolean variable is true, then consider Todo item completed and ready to be removed 
+      // (and remove it anyway in case if onlyCompleted set to false)
+      Serial.print(completed ? "[x]" : "[ ]");
+      Serial.println(menuItemTmp->getTitle());
+      TodoItem* todoItemTmp = (TodoItem*)menuItemTmp->getCallbackData().valPointer; // Get pointer to corresponsing TodoItem object
+      menuItemTmp->remove(); // Remove menu item from menu page
+      delete menuItemTmp; // Delete GEMItem object
+      delete todoItemTmp; // Delete TodoItem object
+      /*
+        Note 1: sometimes (e.g. on ARM-based MCUs, but not on AVR or ESP32) deleting completed Todo items
+        doesn't immediately reflect on the amount of free RAM (as reported by getFreeRam()), however
+        if new Todo item is created afterwards (after deleting completed one) free RAM counter won't change.
+        That shows that deleteing objects is actually works (just not always reflected on the visible amount of free RAM,
+        probably for reasons discussed here: https://forum.arduino.cc/t/memory-no-getting-cleaned-up-after-delete/894404),
+        and new item presumably occupies previously freed memory. This may be related to so-called "buried heap space".
+        Note 2: amount of displayed free RAM may change after moving cursor from button after clearing, for the same amount every
+        time for some reason, even if no actual Todo items was deleted (it may something to do with processes needed to redraw
+        menu and/or stack allocation for clearItems() call). However, previous statement (Note 1) still holds.
+      */
+    }
+    menuItemTmp = nextItem;
+  }
+  calculateFreeRam();
+  menu.drawMenu();
+}
+
+void clearCompleted() {
+  clearItems();
+  flashButtonTitle("Cleared!");
+}
+
+void clearAll() {
+  clearItems(false);
+  flashButtonTitle("Cleared!");
+}

--- a/keywords.txt
+++ b/keywords.txt
@@ -12,6 +12,7 @@ GEMItem	KEYWORD1
 GEMPage	KEYWORD1
 GEMSelect	KEYWORD1
 GEMCallbackData	KEYWORD1
+GEMAppearance	KEYWORD1
 Splash	KEYWORD1
 FontSize	KEYWORD1
 FontFamilies	KEYWORD1
@@ -26,6 +27,7 @@ SelectOptionDouble	KEYWORD1
 # Methods and Functions (KEYWORD2)
 ####################################################
 
+setAppearance	KEYWORD2
 setSplash	KEYWORD2
 setSplashDelay	KEYWORD2
 hideVersion	KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -8,6 +8,7 @@
 
 GEM	KEYWORD1
 GEM_u8g2	KEYWORD1
+GEM_adafruit_gfx	KEYWORD1
 GEMItem	KEYWORD1
 GEMPage	KEYWORD1
 GEMSelect	KEYWORD1
@@ -39,6 +40,7 @@ enableCyrillic	KEYWORD2
 init	KEYWORD2
 reInit	KEYWORD2
 setMenuPageCurrent	KEYWORD2
+getCurrentMenuPage	KEYWORD2
 drawMenu	KEYWORD2
 readyForKey	KEYWORD2
 registerKeyPress	KEYWORD2
@@ -47,7 +49,12 @@ setCallbackVal	KEYWORD2
 getCallbackData	KEYWORD2
 setTitle	KEYWORD2
 getTitle	KEYWORD2
+getMenuItem	KEYWORD2
+getCurrentMenuItem	KEYWORD2
+getCurrentMenuItemIndex	KEYWORD2
+getMenuItemNext	KEYWORD2
 setPrecision	KEYWORD2
+setAdjustedASCIIOrder	KEYWORD2
 setReadonly	KEYWORD2
 getReadonly	KEYWORD2
 hide	KEYWORD2

--- a/src/GEM.cpp
+++ b/src/GEM.cpp
@@ -60,6 +60,9 @@
 #define GEM_CHAR_CODE_UNDERSCORE 95
 #define GEM_CHAR_CODE_LINE 124
 #define GEM_CHAR_CODE_TILDA 126
+#define GEM_CHAR_CODE_BANG 33
+#define GEM_CHAR_CODE_a 97
+#define GEM_CHAR_CODE_ACCENT 96
 
 // Sprite of the default GEM _splash screen (GEM logo v1)
 /*
@@ -634,22 +637,46 @@ void GEM::drawEditValueCursor() {
 }
 
 void GEM::nextEditValueDigit() {
+  GEMItem* menuItemTmp = _menuPageCurrent->getCurrentMenuItem();
   char chr = _valueString[_editValueVirtualCursorPosition];
   byte code = (byte)chr;
   if (_editValueType == GEM_VAL_CHAR) {
-    switch (code) {
-      case 0:
-        code = GEM_CHAR_CODE_SPACE;
-        break;
-      case GEM_CHAR_CODE_TILDA:
-        code = GEM_CHAR_CODE_SPACE;
-        break;
-      case GEM_CHAR_CODE_LINE - 1:
-        code = GEM_CHAR_CODE_LINE + 1;
-        break;
-      default:
-        code++;
-        break;
+    if (menuItemTmp->adjustedAsciiOrder) {
+      switch (code) {
+        case 0:
+          code = GEM_CHAR_CODE_a;
+          break;
+        case GEM_CHAR_CODE_SPACE:
+          code = GEM_CHAR_CODE_a;
+          break;
+        case GEM_CHAR_CODE_ACCENT:
+          code = GEM_CHAR_CODE_SPACE;
+          break;
+        case GEM_CHAR_CODE_TILDA:
+          code = GEM_CHAR_CODE_BANG;
+          break;
+        case GEM_CHAR_CODE_LINE - 1:
+          code = GEM_CHAR_CODE_LINE + 1;
+          break;
+        default:
+          code++;
+          break;
+      }
+    } else {
+      switch (code) {
+        case 0:
+          code = GEM_CHAR_CODE_SPACE;
+          break;
+        case GEM_CHAR_CODE_TILDA:
+          code = GEM_CHAR_CODE_SPACE;
+          break;
+        case GEM_CHAR_CODE_LINE - 1:
+          code = GEM_CHAR_CODE_LINE + 1;
+          break;
+        default:
+          code++;
+          break;
+      }
     }
   } else {
     switch (code) {
@@ -677,22 +704,46 @@ void GEM::nextEditValueDigit() {
 }
 
 void GEM::prevEditValueDigit() {
+  GEMItem* menuItemTmp = _menuPageCurrent->getCurrentMenuItem();
   char chr = _valueString[_editValueVirtualCursorPosition];
   byte code = (byte)chr;
   if (_editValueType == GEM_VAL_CHAR) {
-    switch (code) {
-      case 0:
-        code = GEM_CHAR_CODE_TILDA;
-        break;
-      case GEM_CHAR_CODE_SPACE:
-        code = GEM_CHAR_CODE_TILDA;
-        break;
-      case GEM_CHAR_CODE_LINE + 1:
-        code = GEM_CHAR_CODE_LINE - 1;
-        break;
-      default:
-        code--;
-        break;
+    if (menuItemTmp->adjustedAsciiOrder) {
+      switch (code) {
+        case 0:
+          code = GEM_CHAR_CODE_TILDA;
+          break;
+        case GEM_CHAR_CODE_BANG:
+          code = GEM_CHAR_CODE_TILDA;
+          break;
+        case GEM_CHAR_CODE_a:
+          code = GEM_CHAR_CODE_SPACE;
+          break;
+        case GEM_CHAR_CODE_SPACE:
+          code = GEM_CHAR_CODE_ACCENT;
+          break;
+        case GEM_CHAR_CODE_LINE + 1:
+          code = GEM_CHAR_CODE_LINE - 1;
+          break;
+        default:
+          code--;
+          break;
+      }
+    } else {
+      switch (code) {
+        case 0:
+          code = GEM_CHAR_CODE_TILDA;
+          break;
+        case GEM_CHAR_CODE_SPACE:
+          code = GEM_CHAR_CODE_TILDA;
+          break;
+        case GEM_CHAR_CODE_LINE + 1:
+          code = GEM_CHAR_CODE_LINE - 1;
+          break;
+        default:
+          code--;
+          break;
+      }
     }
   } else {
     switch (code) {

--- a/src/GEM.cpp
+++ b/src/GEM.cpp
@@ -711,7 +711,7 @@ void GEM::prevEditValueDigit() {
     if (menuItemTmp->adjustedAsciiOrder) {
       switch (code) {
         case 0:
-          code = GEM_CHAR_CODE_TILDA;
+          code = GEM_CHAR_CODE_ACCENT;
           break;
         case GEM_CHAR_CODE_BANG:
           code = GEM_CHAR_CODE_TILDA;

--- a/src/GEM.cpp
+++ b/src/GEM.cpp
@@ -237,6 +237,10 @@ GEM& GEM::setMenuPageCurrent(GEMPage& menuPageCurrent) {
   return *this;
 }
 
+GEMPage* GEM::getCurrentMenuPage() {
+  return _menuPageCurrent;
+}
+
 //====================== CONTEXT OPERATIONS
 
 GEM& GEM::clearContext() {

--- a/src/GEM.h
+++ b/src/GEM.h
@@ -40,6 +40,7 @@
 #ifdef GEM_ENABLE_GLCD_VERSION
 
 #include <AltSerialGraphicLCD.h>
+#include "GEMAppearance.h"
 #include "GEMPage.h"
 #include "GEMSelect.h"
 #include "constants.h"
@@ -94,6 +95,15 @@ class GEM {
       default 86 (suitable for 128x64 screen with other variables at their default values)
     */
     GEM(GLCD& glcd_, byte menuPointerType_ = GEM_POINTER_ROW, byte menuItemsPerScreen_ = 5, byte menuItemHeight_ = 10, byte menuPageScreenTopOffset_ = 10, byte menuValuesLeftOffset_ = 86);
+    /*
+      @param 'glcd_' - reference to the instance of the GLCD class created with AltSerialGraphicLCD library
+      @param 'appearance_' - object of type GEMAppearance
+    */
+    GEM(GLCD& glcd_, GEMAppearance appearance_);
+
+    /* APPEARANCE OPERATIONS */
+
+    GEM& setAppearance(GEMAppearance appearance);       // Set apperance of the menu (can be overridden in GEMPage on per page basis)
 
     /* INIT OPERATIONS */
 
@@ -129,17 +139,15 @@ class GEM {
                                                          // Accepts GEM_KEY_NONE, GEM_KEY_UP, GEM_KEY_RIGHT, GEM_KEY_DOWN, GEM_KEY_LEFT, GEM_KEY_CANCEL, GEM_KEY_OK values
   private:
     GLCD& _glcd;
-    byte _menuPointerType;
-    byte _menuItemsPerScreen;
-    byte _menuItemHeight;
-    byte _menuPageScreenTopOffset;
-    byte _menuValuesLeftOffset;
-    byte _menuItemFontSize;
+    GEMAppearance* _appearanceCurrent = nullptr;
+    GEMAppearance _appearance;
+    GEMAppearance* getCurrentAppearance();
+    byte getMenuItemsPerScreen();
+    byte getMenuItemFontSize();
     FontSize _menuItemFont[2] = {{6,8},{4,6}};
     bool _invertKeysDuringEdit = false;
-    byte _menuItemInsetOffset;
-    byte _menuItemTitleLength;
-    byte _menuItemValueLength;
+    byte getMenuItemTitleLength();
+    byte getMenuItemValueLength();
     const uint8_t *_splash;
     uint16_t _splashDelay = 1000;
     bool _enableVersion = true;

--- a/src/GEM.h
+++ b/src/GEM.h
@@ -122,6 +122,7 @@ class GEM {
     GEM& init();                                        // Init the menu (load necessary sprites into RAM of the SparkFun Graphic LCD Serial Backpack, display GEM splash screen, etc.)
     GEM& reInit();                                      // Reinitialize the menu (apply GEM specific settings to AltSerialGraphicLCD library)
     GEM& setMenuPageCurrent(GEMPage& menuPageCurrent);  // Set supplied menu page as current
+    GEMPage* getCurrentMenuPage();                      // Get pointer to current menu page
 
     /* CONTEXT OPERATIONS */
 

--- a/src/GEMAppearance.h
+++ b/src/GEMAppearance.h
@@ -1,0 +1,49 @@
+/*
+  GEMAppearance - struct for storing visual settings of GEM library.
+
+  GEM (a.k.a. Good Enough Menu) - Arduino library for creation of graphic multi-level menu with
+  editable menu items, such as variables (supports int, byte, float, double, bool, char[17] data types)
+  and option selects. User-defined callback function can be specified to invoke when menu item is saved.
+  
+  Supports buttons that can invoke user-defined actions and create action-specific
+  context, which can have its own enter (setup) and exit callbacks as well as loop function.
+
+  Supports:
+  - AltSerialGraphicLCD library by Jon Green (http://www.jasspa.com/serialGLCD.html);
+  - U8g2 library by olikraus (https://github.com/olikraus/U8g2_Arduino);
+  - Adafruit GFX library by Adafruit (https://github.com/adafruit/Adafruit-GFX-Library).
+
+  For documentation visit:
+  https://github.com/Spirik/GEM
+
+  Copyright (c) 2018-2023 Alexander 'Spirik' Spiridonov
+
+  This file is part of GEM library.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+  
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  Lesser General Public License for more details.
+  
+  You should have received a copy of the GNU Lesser General Public License
+  along with this library.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef HEADER_GEMAPPEARANCE
+#define HEADER_GEMAPPEARANCE
+
+// Declaration of GEMAppearance type
+struct GEMAppearance {
+  byte menuPointerType;
+  byte menuItemsPerScreen;
+  byte menuItemHeight;
+  byte menuPageScreenTopOffset;
+  byte menuValuesLeftOffset;
+};
+  
+#endif

--- a/src/GEMItem.cpp
+++ b/src/GEMItem.cpp
@@ -1273,36 +1273,43 @@ GEMItem::GEMItem(const char* title_, void (*callbackAction_)(GEMCallbackData), v
 //---
 
 GEMItem& GEMItem::setCallbackVal(byte callbackVal_) {
+  callbackData.pMenuItem = this;
   callbackData.valByte = callbackVal_;
   return *this;
 }
 
 GEMItem& GEMItem::setCallbackVal(int callbackVal_) {
+  callbackData.pMenuItem = this;
   callbackData.valInt = callbackVal_;
   return *this;
 }
 
 GEMItem& GEMItem::setCallbackVal(float callbackVal_) {
+  callbackData.pMenuItem = this;
   callbackData.valFloat = callbackVal_;
   return *this;
 }
 
 GEMItem& GEMItem::setCallbackVal(double callbackVal_) {
+  callbackData.pMenuItem = this;
   callbackData.valDouble = callbackVal_;
   return *this;
 }
 
 GEMItem& GEMItem::setCallbackVal(bool callbackVal_) {
+  callbackData.pMenuItem = this;
   callbackData.valBool = callbackVal_;
   return *this;
 }
 
 GEMItem& GEMItem::setCallbackVal(const char* callbackVal_) {
+  callbackData.pMenuItem = this;
   callbackData.valChar = callbackVal_;
   return *this;
 }
 
 GEMItem& GEMItem::setCallbackVal(void* callbackVal_) {
+  callbackData.pMenuItem = this;
   callbackData.valPointer = callbackVal_;
   return *this;
 }

--- a/src/GEMItem.cpp
+++ b/src/GEMItem.cpp
@@ -1334,6 +1334,11 @@ GEMItem& GEMItem::setPrecision(byte prec) {
   return *this;
 }
 
+GEMItem& GEMItem::setAdjustedASCIIOrder(bool mode) {
+  adjustedAsciiOrder = mode;
+  return *this;
+}
+
 GEMItem& GEMItem::setReadonly(bool mode) {
   readonly = mode;
   return *this;

--- a/src/GEMItem.h
+++ b/src/GEMItem.h
@@ -266,28 +266,29 @@ class GEMItem {
     GEMItem(const char* title_, void (*callbackAction_)(GEMCallbackData), const char* callbackVal_, bool readonly_ = false);
     GEMItem(const char* title_, void (*callbackAction_)(GEMCallbackData), void* callbackVal_, bool readonly_ = false);
 
-    GEMItem& setCallbackVal(byte callbackVal_); // Set value of an argument that will be passed to callback within GEMCallbackData (either byte, int, bool, float, double, char or void pointer)
+    GEMItem& setCallbackVal(byte callbackVal_);   // Set value of an argument that will be passed to callback within GEMCallbackData (either byte, int, bool, float, double, char or void pointer)
     GEMItem& setCallbackVal(int callbackVal_);
     GEMItem& setCallbackVal(float callbackVal_);
     GEMItem& setCallbackVal(double callbackVal_);
     GEMItem& setCallbackVal(bool callbackVal_);
     GEMItem& setCallbackVal(const char* callbackVal_);
     GEMItem& setCallbackVal(void* callbackVal_);
-    GEMCallbackData getCallbackData();          // Get GEMCallbackData struct associated with menu item
-    GEMItem& setTitle(const char* title_);      // Set title of the menu item
-    const char* getTitle();                     // Get title of the menu item
-    GEMItem& setPrecision(byte prec);           // Explicitly set precision for float or double variables as required by dtostrf() conversion,
-                                                // i.e. the number of digits after the decimal sign
-    GEMItem& setReadonly(bool mode = true);     // Explicitly set or unset readonly mode for variable that menu item is associated with
-                                                // (relevant for GEM_VAL_INTEGER, GEM_VAL_BYTE, GEM_VAL_FLOAT, GEM_VAL_DOUBLE, GEM_VAL_CHAR,
-                                                // GEM_VAL_BOOL variable menu items and GEM_VAL_SELECT option select), or menu button GEM_ITEM_BUTTON
-                                                // and menu link GEM_ITEM_LINK, pressing of which won't result in any action, associated with them
-    bool getReadonly();                         // Get readonly state of the variable that menu item is associated with (as well as menu link or button)
-    GEMItem& hide(bool hide = true);            // Explicitly hide or show menu item
-    GEMItem& show();                            // Explicitly show menu item
-    bool getHidden();                           // Get hidden state of the menu item
-    GEMItem& remove();                          // Remove menu item from parent menu page
-    void* getLinkedVariablePointer();           // Get pointer to a linked variable (relevant for menu items that represent variable)
+    GEMCallbackData getCallbackData();            // Get GEMCallbackData struct associated with menu item
+    GEMItem& setTitle(const char* title_);        // Set title of the menu item
+    const char* getTitle();                       // Get title of the menu item
+    GEMItem& setPrecision(byte prec);             // Explicitly set precision for float or double variables as required by dtostrf() conversion,
+                                                  // i.e. the number of digits after the decimal sign
+    GEMItem& setReadonly(bool mode = true);       // Explicitly set or unset readonly mode for variable that menu item is associated with
+                                                  // (relevant for GEM_VAL_INTEGER, GEM_VAL_BYTE, GEM_VAL_FLOAT, GEM_VAL_DOUBLE, GEM_VAL_CHAR,
+                                                  // GEM_VAL_BOOL variable menu items and GEM_VAL_SELECT option select), or menu button GEM_ITEM_BUTTON
+                                                  // and menu link GEM_ITEM_LINK, pressing of which won't result in any action, associated with them
+    bool getReadonly();                           // Get readonly state of the variable that menu item is associated with (as well as menu link or button)
+    GEMItem& hide(bool hide = true);              // Explicitly hide or show menu item
+    GEMItem& show();                              // Explicitly show menu item
+    bool getHidden();                             // Get hidden state of the menu item
+    GEMItem& remove();                            // Remove menu item from parent menu page
+    void* getLinkedVariablePointer();             // Get pointer to a linked variable (relevant for menu items that represent variable)
+    GEMItem* getMenuItemNext(bool total = false); // Get next menu item (including hidden ones if total set to true)
   private:
     const char* title;
     void* linkedVariable = nullptr;
@@ -306,7 +307,6 @@ class GEMItem {
     };
     bool callbackWithArgs = false;
     GEMCallbackData callbackData;
-    GEMItem* getMenuItemNext(bool total = false); // Get next menu item (including hidden ones if total set to true)
 };
   
 #endif

--- a/src/GEMItem.h
+++ b/src/GEMItem.h
@@ -266,35 +266,37 @@ class GEMItem {
     GEMItem(const char* title_, void (*callbackAction_)(GEMCallbackData), const char* callbackVal_, bool readonly_ = false);
     GEMItem(const char* title_, void (*callbackAction_)(GEMCallbackData), void* callbackVal_, bool readonly_ = false);
 
-    GEMItem& setCallbackVal(byte callbackVal_);   // Set value of an argument that will be passed to callback within GEMCallbackData (either byte, int, bool, float, double, char or void pointer)
+    GEMItem& setCallbackVal(byte callbackVal_);         // Set value of an argument that will be passed to callback within GEMCallbackData (either byte, int, bool, float, double, char or void pointer)
     GEMItem& setCallbackVal(int callbackVal_);
     GEMItem& setCallbackVal(float callbackVal_);
     GEMItem& setCallbackVal(double callbackVal_);
     GEMItem& setCallbackVal(bool callbackVal_);
     GEMItem& setCallbackVal(const char* callbackVal_);
     GEMItem& setCallbackVal(void* callbackVal_);
-    GEMCallbackData getCallbackData();            // Get GEMCallbackData struct associated with menu item
-    GEMItem& setTitle(const char* title_);        // Set title of the menu item
-    const char* getTitle();                       // Get title of the menu item
-    GEMItem& setPrecision(byte prec);             // Explicitly set precision for float or double variables as required by dtostrf() conversion,
-                                                  // i.e. the number of digits after the decimal sign
-    GEMItem& setReadonly(bool mode = true);       // Explicitly set or unset readonly mode for variable that menu item is associated with
-                                                  // (relevant for GEM_VAL_INTEGER, GEM_VAL_BYTE, GEM_VAL_FLOAT, GEM_VAL_DOUBLE, GEM_VAL_CHAR,
-                                                  // GEM_VAL_BOOL variable menu items and GEM_VAL_SELECT option select), or menu button GEM_ITEM_BUTTON
-                                                  // and menu link GEM_ITEM_LINK, pressing of which won't result in any action, associated with them
-    bool getReadonly();                           // Get readonly state of the variable that menu item is associated with (as well as menu link or button)
-    GEMItem& hide(bool hide = true);              // Explicitly hide or show menu item
-    GEMItem& show();                              // Explicitly show menu item
-    bool getHidden();                             // Get hidden state of the menu item
-    GEMItem& remove();                            // Remove menu item from parent menu page
-    void* getLinkedVariablePointer();             // Get pointer to a linked variable (relevant for menu items that represent variable)
-    GEMItem* getMenuItemNext(bool total = false); // Get next menu item (including hidden ones if total set to true)
+    GEMCallbackData getCallbackData();                  // Get GEMCallbackData struct associated with menu item
+    GEMItem& setTitle(const char* title_);              // Set title of the menu item
+    const char* getTitle();                             // Get title of the menu item
+    GEMItem& setPrecision(byte prec);                   // Explicitly set precision for float or double variables as required by dtostrf() conversion,
+                                                        // i.e. the number of digits after the decimal sign
+    GEMItem& setAdjustedASCIIOrder(bool mode = true);   // Turn adjsuted order of characters when editing char[17] variables on (with space character followed by `a` and preceded by `) or off
+    GEMItem& setReadonly(bool mode = true);             // Explicitly set or unset readonly mode for variable that menu item is associated with
+                                                        // (relevant for GEM_VAL_INTEGER, GEM_VAL_BYTE, GEM_VAL_FLOAT, GEM_VAL_DOUBLE, GEM_VAL_CHAR,
+                                                        // GEM_VAL_BOOL variable menu items and GEM_VAL_SELECT option select), or menu button GEM_ITEM_BUTTON
+                                                        // and menu link GEM_ITEM_LINK, pressing of which won't result in any action, associated with them
+    bool getReadonly();                                 // Get readonly state of the variable that menu item is associated with (as well as menu link or button)
+    GEMItem& hide(bool hide = true);                    // Explicitly hide or show menu item
+    GEMItem& show();                                    // Explicitly show menu item
+    bool getHidden();                                   // Get hidden state of the menu item
+    GEMItem& remove();                                  // Remove menu item from parent menu page
+    void* getLinkedVariablePointer();                   // Get pointer to a linked variable (relevant for menu items that represent variable)
+    GEMItem* getMenuItemNext(bool total = false);       // Get next menu item (including hidden ones if total set to true)
   private:
     const char* title;
     void* linkedVariable = nullptr;
     byte linkedType;
     byte type;
     byte precision = GEM_FLOAT_PREC;
+    bool adjustedAsciiOrder = false;
     bool readonly = false;
     bool hidden = false;
     GEMSelect* select = nullptr;

--- a/src/GEMPage.cpp
+++ b/src/GEMPage.cpp
@@ -129,6 +129,10 @@ GEMItem* GEMPage::getCurrentMenuItem() {
   return getMenuItem(currentItemNum);
 }
 
+byte GEMPage::getCurrentMenuItemIndex() {
+  return currentItemNum;
+}
+
 int GEMPage::getMenuItemNum(GEMItem& menuItem, bool total) {
   GEMItem* menuItemTmp = (!total && _menuItem->hidden) ? _menuItem->getMenuItemNext() : _menuItem;
   for (byte i=0; i<(total ? itemsCountTotal : itemsCount); i++) {

--- a/src/GEMPage.cpp
+++ b/src/GEMPage.cpp
@@ -109,6 +109,11 @@ const char* GEMPage::getTitle() {
   return title;
 }
 
+GEMPage& GEMPage::setAppearance(GEMAppearance* appearance) {
+  _appearance = appearance;
+  return *this;
+}
+
 GEMItem* GEMPage::getMenuItem(byte index, bool total) {
   GEMItem* menuItemTmp = (!total && _menuItem->hidden) ? _menuItem->getMenuItemNext() : _menuItem;
   for (byte i=0; i<index; i++) {

--- a/src/GEMPage.h
+++ b/src/GEMPage.h
@@ -38,6 +38,7 @@
 #define HEADER_GEMPAGE
 
 #include <Arduino.h>
+#include "GEMAppearance.h"
 #include "GEMItem.h"
 
 // Macro constant (alias) for the last possible position that menu item can be added at
@@ -68,6 +69,7 @@ class GEMPage {
     GEMPage& setParentMenuPage(GEMPage& parentMenuPage);        // Specify parent level menu page (to know where to go back to when Back button is pressed)
     GEMPage& setTitle(const char* title_);                      // Set title of the menu page
     const char* getTitle();                                     // Get title of the menu page
+    GEMPage& setAppearance(GEMAppearance* appearance);          // Set appearance of the menu page
   private:
     const char* title;
     byte currentItemNum = 0;                                    // Currently selected (focused) menu item of the page
@@ -83,6 +85,7 @@ class GEMPage {
     GEMItem _menuItemBack {"", static_cast<GEMPage*>(nullptr)}; // Local instance of Back button (created when parent level menu page is specified through
                                                                 // setParentMenuPage(); always becomes the first menu item in a list)
     void (*exitAction)() = nullptr;
+    GEMAppearance* _appearance = nullptr;
 };
   
 #endif

--- a/src/GEMPage.h
+++ b/src/GEMPage.h
@@ -70,13 +70,14 @@ class GEMPage {
     GEMPage& setTitle(const char* title_);                      // Set title of the menu page
     const char* getTitle();                                     // Get title of the menu page
     GEMPage& setAppearance(GEMAppearance* appearance);          // Set appearance of the menu page
-    GEMItem* getMenuItem(byte index, bool total = false);       // Get menu item by index (counting hidden ones if total set to true)
+    GEMItem* getMenuItem(byte index, bool total = false);       // Get pointer to menu item by index (counting hidden ones if total set to true)
+    GEMItem* getCurrentMenuItem();                              // Get pointer to current menu item
+    byte getCurrentMenuItemIndex();                             // Get index of current menu item
   private:
     const char* title;
     byte currentItemNum = 0;                                    // Currently selected (focused) menu item of the page
     byte itemsCount = 0;                                        // Items count excluding hidden ones
     byte itemsCountTotal = 0;                                   // Items count incuding hidden ones
-    GEMItem* getCurrentMenuItem();
     int getMenuItemNum(GEMItem& menuItem, bool total = false);  // Find index of the supplied menu item
     void hideMenuItem(GEMItem& menuItem);
     void showMenuItem(GEMItem& menuItem);

--- a/src/GEMPage.h
+++ b/src/GEMPage.h
@@ -70,12 +70,12 @@ class GEMPage {
     GEMPage& setTitle(const char* title_);                      // Set title of the menu page
     const char* getTitle();                                     // Get title of the menu page
     GEMPage& setAppearance(GEMAppearance* appearance);          // Set appearance of the menu page
+    GEMItem* getMenuItem(byte index, bool total = false);       // Get menu item by index (counting hidden ones if total set to true)
   private:
     const char* title;
     byte currentItemNum = 0;                                    // Currently selected (focused) menu item of the page
     byte itemsCount = 0;                                        // Items count excluding hidden ones
     byte itemsCountTotal = 0;                                   // Items count incuding hidden ones
-    GEMItem* getMenuItem(byte index, bool total = false);
     GEMItem* getCurrentMenuItem();
     int getMenuItemNum(GEMItem& menuItem, bool total = false);  // Find index of the supplied menu item
     void hideMenuItem(GEMItem& menuItem);

--- a/src/GEM_adafruit_gfx.cpp
+++ b/src/GEM_adafruit_gfx.cpp
@@ -348,6 +348,10 @@ GEM_adafruit_gfx& GEM_adafruit_gfx::setMenuPageCurrent(GEMPage& menuPageCurrent)
   return *this;
 }
 
+GEMPage* GEM_adafruit_gfx::getCurrentMenuPage() {
+  return _menuPageCurrent;
+}
+
 //====================== CONTEXT OPERATIONS
 
 GEM_adafruit_gfx& GEM_adafruit_gfx::clearContext() {

--- a/src/GEM_adafruit_gfx.cpp
+++ b/src/GEM_adafruit_gfx.cpp
@@ -203,14 +203,13 @@ const Splash selectArrows[] = {
 
 GEM_adafruit_gfx::GEM_adafruit_gfx(Adafruit_GFX& agfx_, byte menuPointerType_, byte menuItemsPerScreen_, byte menuItemHeight_, byte menuPageScreenTopOffset_, byte menuValuesLeftOffset_)
   : _agfx(agfx_)
-  , _menuPointerType(menuPointerType_)
-  , _menuItemsPerScreen(menuItemsPerScreen_)
-  , _menuItemHeight(menuItemHeight_)
-  , _menuPageScreenTopOffset(menuPageScreenTopOffset_)
-  , _menuValuesLeftOffset(menuValuesLeftOffset_)
 {
-  _menuItemFontSize = _menuItemHeight >= 8 * _textSize ? 0 : 1;
-  _menuItemInsetOffset = (_menuItemHeight - _menuItemFont[_menuItemFontSize].height * _textSize) / 2;
+  _appearance.menuPointerType = menuPointerType_;
+  _appearance.menuItemsPerScreen = menuItemsPerScreen_;
+  _appearance.menuItemHeight = menuItemHeight_;
+  _appearance.menuPageScreenTopOffset = menuPageScreenTopOffset_;
+  _appearance.menuValuesLeftOffset = menuValuesLeftOffset_;
+  _appearanceCurrent = &_appearance;
   _splash = logo[_textSize > 1 ? 1 : 0];
   clearContext();
   _editValueMode = false;
@@ -218,6 +217,47 @@ GEM_adafruit_gfx::GEM_adafruit_gfx(Adafruit_GFX& agfx_, byte menuPointerType_, b
   memset(_valueString, '\0', GEM_STR_LEN - 1);
   _valueSelectNum = -1;
 }
+
+GEM_adafruit_gfx::GEM_adafruit_gfx(Adafruit_GFX& agfx_, GEMAppearance appearance_)
+  : _agfx(agfx_)
+  , _appearance(appearance_)
+{
+  _appearanceCurrent = &_appearance;
+  _splash = logo[_textSize > 1 ? 1 : 0];
+  clearContext();
+  _editValueMode = false;
+  _editValueCursorPosition = 0;
+  memset(_valueString, '\0', GEM_STR_LEN - 1);
+  _valueSelectNum = -1;
+}
+
+//====================== APPEARANCE OPERATIONS
+
+GEM_adafruit_gfx& GEM_adafruit_gfx::setAppearance(GEMAppearance appearance) {
+  _appearance = appearance;
+  return *this;
+}
+
+GEMAppearance* GEM_adafruit_gfx::getCurrentAppearance() {
+  return (_menuPageCurrent != nullptr && _menuPageCurrent->_appearance != nullptr) ? _menuPageCurrent->_appearance : &_appearance;
+}
+
+byte GEM_adafruit_gfx::getMenuItemsPerScreen() {
+  return getCurrentAppearance()->menuItemsPerScreen == GEM_ITEMS_COUNT_AUTO ? (_agfx.height() - getCurrentAppearance()->menuPageScreenTopOffset) / getCurrentAppearance()->menuItemHeight : getCurrentAppearance()->menuItemsPerScreen;
+}
+
+byte GEM_adafruit_gfx::getMenuItemFontSize() {
+  return getCurrentAppearance()->menuItemHeight >= 8 * _textSize ? 0 : 1;
+}
+
+byte GEM_adafruit_gfx::getMenuItemTitleLength() {
+  return (getCurrentAppearance()->menuValuesLeftOffset - 5 * _textSize) / (_menuItemFont[getMenuItemFontSize()].width * _textSize);
+}
+
+byte GEM_adafruit_gfx::getMenuItemValueLength() {
+  return (_agfx.width() - getCurrentAppearance()->menuValuesLeftOffset - 6 * _textSize) / (_menuItemFont[getMenuItemFontSize()].width * _textSize);
+}
+
 
 //====================== INIT OPERATIONS
 
@@ -238,8 +278,6 @@ GEM_adafruit_gfx& GEM_adafruit_gfx::hideVersion(bool flag) {
 
 GEM_adafruit_gfx& GEM_adafruit_gfx::setTextSize(uint8_t size) {
   _textSize = size > 0 ? size : 1;
-  _menuItemFontSize = _menuItemHeight >= 8 * _textSize ? 0 : 1;
-  _menuItemInsetOffset = (_menuItemHeight - _menuItemFont[_menuItemFontSize].height * _textSize) / 2;
   if (_splash.image == logo[0].image || _splash.image == logo[1].image) {
     _splash = logo[_textSize > 1 ? 1 : 0];
   }
@@ -266,12 +304,6 @@ GEM_adafruit_gfx& GEM_adafruit_gfx::init() {
   _agfx.setTextWrap(false);
   _agfx.setTextColor(_menuForegroundColor);
   _agfx.fillScreen(_menuBackgroundColor);
-  
-  _menuItemTitleLength = (_menuValuesLeftOffset - 5 * _textSize) / (_menuItemFont[_menuItemFontSize].width * _textSize);
-  _menuItemValueLength = (_agfx.width() - _menuValuesLeftOffset - 6 * _textSize) / (_menuItemFont[_menuItemFontSize].width * _textSize);
-  if (_menuItemsPerScreen == GEM_ITEMS_COUNT_AUTO) {
-    _menuItemsPerScreen = (_agfx.height() - _menuPageScreenTopOffset) / _menuItemHeight;
-  }
 
   if (_splashDelay > 0) {
 
@@ -342,7 +374,7 @@ void GEM_adafruit_gfx::drawTitleBar() {
   _agfx.setCursor(5 * _textSize, _menuItemFont[1].baselineOffset * _textSize + 1);
   _agfx.print(_menuPageCurrent->title);
   _agfx.setTextWrap(false);
-  _agfx.setFont(_menuItemFontSize ? _fontFamilies.small : _fontFamilies.big);
+  _agfx.setFont(getMenuItemFontSize() ? _fontFamilies.small : _fontFamilies.big);
 }
 
 void GEM_adafruit_gfx::drawSprite(int16_t x, int16_t y, const Splash sprite[], uint16_t color) {
@@ -359,79 +391,84 @@ void GEM_adafruit_gfx::printMenuItemString(const char* str, byte num, byte start
 }
 
 void GEM_adafruit_gfx::printMenuItemTitle(const char* str, int offset) {
-  printMenuItemString(str, _menuItemTitleLength + offset);
+  printMenuItemString(str, getMenuItemTitleLength() + offset);
 }
 
 void GEM_adafruit_gfx::printMenuItemValue(const char* str, int offset, byte startPos) {
-  printMenuItemString(str, _menuItemValueLength + offset, startPos);
+  printMenuItemString(str, getMenuItemValueLength() + offset, startPos);
 }
 
 void GEM_adafruit_gfx::printMenuItemFull(const char* str, int offset) {
-  printMenuItemString(str, _menuItemTitleLength + _menuItemValueLength + offset);
+  printMenuItemString(str, getMenuItemTitleLength() + getMenuItemValueLength() + offset);
 }
 
 byte GEM_adafruit_gfx::getMenuItemInsetOffset(bool forSprite) {
+  byte menuItemFontSize = getMenuItemFontSize();
   byte spriteHeight = _textSize > 1 ? sprite_height_scaled : sprite_height;
-  return _menuItemInsetOffset + (forSprite ? (_menuItemFont[_menuItemFontSize].height * _textSize - spriteHeight) / 2 : (_menuItemFontSize ? -1 * _textSize : -2 * _textSize)); // With additional offset for sprites and text for better visual alignment
+  byte menuItemInsetOffset = (getCurrentAppearance()->menuItemHeight - _menuItemFont[menuItemFontSize].height * _textSize) / 2;
+  return menuItemInsetOffset + (forSprite ? (_menuItemFont[menuItemFontSize].height * _textSize - spriteHeight) / 2 : (menuItemFontSize ? -1 * _textSize : -2 * _textSize)); // With additional offset for sprites and text for better visual alignment
 }
 
 byte GEM_adafruit_gfx::getCurrentItemTopOffset(bool withInsetOffset, bool forSprite) {
-  return (_menuPageCurrent->currentItemNum % _menuItemsPerScreen) * _menuItemHeight + _menuPageScreenTopOffset + (withInsetOffset ? getMenuItemInsetOffset(forSprite) : 0);
+  return (_menuPageCurrent->currentItemNum % getMenuItemsPerScreen()) * getCurrentAppearance()->menuItemHeight + getCurrentAppearance()->menuPageScreenTopOffset + (withInsetOffset ? getMenuItemInsetOffset(forSprite) : 0);
 }
 
 void GEM_adafruit_gfx::printMenuItem(GEMItem* menuItemTmp, byte yText, byte yDraw, uint16_t color) {
   _agfx.setTextColor(color);
   switch (menuItemTmp->type) {
       case GEM_ITEM_VAL:
-        _agfx.setCursor(5 * _textSize, yText);
-        if (menuItemTmp->readonly) {
-          printMenuItemTitle(menuItemTmp->title, -1);
-          _agfx.print("^");
-        } else {
-          printMenuItemTitle(menuItemTmp->title);
-        }
+        {
+          _agfx.setCursor(5 * _textSize, yText);
+          if (menuItemTmp->readonly) {
+            printMenuItemTitle(menuItemTmp->title, -1);
+            _agfx.print("^");
+          } else {
+            printMenuItemTitle(menuItemTmp->title);
+          }
 
-        _agfx.setCursor(_menuValuesLeftOffset, yText);
-        switch (menuItemTmp->linkedType) {
-          case GEM_VAL_INTEGER:
-            itoa(*(int*)menuItemTmp->linkedVariable, _valueString, 10);
-            printMenuItemValue(_valueString);
-            break;
-          case GEM_VAL_BYTE:
-            itoa(*(byte*)menuItemTmp->linkedVariable, _valueString, 10);
-            printMenuItemValue(_valueString);
-            break;
-          case GEM_VAL_CHAR:
-            printMenuItemValue((char*)menuItemTmp->linkedVariable);
-            break;
-          case GEM_VAL_BOOL:
-            if (*(bool*)menuItemTmp->linkedVariable) {
-              drawSprite(_menuValuesLeftOffset, yDraw, checkboxChecked, color);
-            } else {
-              drawSprite(_menuValuesLeftOffset, yDraw, checkboxUnchecked, color);
-            }
-            break;
-          case GEM_VAL_SELECT:
-            {
-              GEMSelect* select = menuItemTmp->select;
-              printMenuItemValue(select->getSelectedOptionName(menuItemTmp->linkedVariable));
-              drawSprite(_agfx.width() - 7 * _textSize, yDraw, selectArrows, color);
-            }
-            break;
-          #ifdef GEM_SUPPORT_FLOAT_EDIT
-          case GEM_VAL_FLOAT:
-            // sprintf(_valueString,"%.6f", *(float*)menuItemTmp->linkedVariable); // May work for non-AVR boards
-            dtostrf(*(float*)menuItemTmp->linkedVariable, menuItemTmp->precision + 1, menuItemTmp->precision, _valueString);
-            printMenuItemValue(_valueString);
-            break;
-          case GEM_VAL_DOUBLE:
-            // sprintf(_valueString,"%.6f", *(double*)menuItemTmp->linkedVariable); // May work for non-AVR boards
-            dtostrf(*(double*)menuItemTmp->linkedVariable, menuItemTmp->precision + 1, menuItemTmp->precision, _valueString);
-            printMenuItemValue(_valueString);
-            break;
-          #endif
+          byte menuValuesLeftOffset = getCurrentAppearance()->menuValuesLeftOffset;
+          _agfx.setCursor(menuValuesLeftOffset, yText);
+          switch (menuItemTmp->linkedType) {
+            case GEM_VAL_INTEGER:
+              itoa(*(int*)menuItemTmp->linkedVariable, _valueString, 10);
+              printMenuItemValue(_valueString);
+              break;
+            case GEM_VAL_BYTE:
+              itoa(*(byte*)menuItemTmp->linkedVariable, _valueString, 10);
+              printMenuItemValue(_valueString);
+              break;
+            case GEM_VAL_CHAR:
+              printMenuItemValue((char*)menuItemTmp->linkedVariable);
+              break;
+            case GEM_VAL_BOOL:
+              if (*(bool*)menuItemTmp->linkedVariable) {
+                drawSprite(menuValuesLeftOffset, yDraw, checkboxChecked, color);
+              } else {
+                drawSprite(menuValuesLeftOffset, yDraw, checkboxUnchecked, color);
+              }
+              break;
+            case GEM_VAL_SELECT:
+              {
+                GEMSelect* select = menuItemTmp->select;
+                printMenuItemValue(select->getSelectedOptionName(menuItemTmp->linkedVariable));
+                drawSprite(_agfx.width() - 7 * _textSize, yDraw, selectArrows, color);
+              }
+              break;
+            #ifdef GEM_SUPPORT_FLOAT_EDIT
+            case GEM_VAL_FLOAT:
+              // sprintf(_valueString,"%.6f", *(float*)menuItemTmp->linkedVariable); // May work for non-AVR boards
+              dtostrf(*(float*)menuItemTmp->linkedVariable, menuItemTmp->precision + 1, menuItemTmp->precision, _valueString);
+              printMenuItemValue(_valueString);
+              break;
+            case GEM_VAL_DOUBLE:
+              // sprintf(_valueString,"%.6f", *(double*)menuItemTmp->linkedVariable); // May work for non-AVR boards
+              dtostrf(*(double*)menuItemTmp->linkedVariable, menuItemTmp->precision + 1, menuItemTmp->precision, _valueString);
+              printMenuItemValue(_valueString);
+              break;
+            #endif
+          }
+          break;
         }
-        break;
       case GEM_ITEM_LINK:
         _agfx.setCursor(5 * _textSize, yText);
         if (menuItemTmp->readonly) {
@@ -443,11 +480,11 @@ void GEM_adafruit_gfx::printMenuItem(GEMItem* menuItemTmp, byte yText, byte yDra
         drawSprite(_agfx.width() - 8 * _textSize, yDraw, arrowRight, color);
         break;
       case GEM_ITEM_BACK:
-        _agfx.setCursor((5 + _menuItemFont[_menuItemFontSize].width) * _textSize, yText);
+        _agfx.setCursor((5 + _menuItemFont[getMenuItemFontSize()].width) * _textSize, yText);
         drawSprite(5 * _textSize, yDraw, arrowLeft, color);
         break;
       case GEM_ITEM_BUTTON:
-        _agfx.setCursor((5 + _menuItemFont[_menuItemFontSize].width) * _textSize, yText);
+        _agfx.setCursor((5 + _menuItemFont[getMenuItemFontSize()].width) * _textSize, yText);
         if (menuItemTmp->readonly) {
           printMenuItemFull(menuItemTmp->title, -1);
           _agfx.print("^");
@@ -461,18 +498,19 @@ void GEM_adafruit_gfx::printMenuItem(GEMItem* menuItemTmp, byte yText, byte yDra
 }
 
 void GEM_adafruit_gfx::printMenuItems() {
-  byte currentPageScreenNum = _menuPageCurrent->currentItemNum / _menuItemsPerScreen;
-  GEMItem* menuItemTmp = _menuPageCurrent->getMenuItem(currentPageScreenNum * _menuItemsPerScreen);
-  byte y = _menuPageScreenTopOffset;
+  byte menuItemsPerScreen = getMenuItemsPerScreen();
+  byte currentPageScreenNum = _menuPageCurrent->currentItemNum / menuItemsPerScreen;
+  GEMItem* menuItemTmp = _menuPageCurrent->getMenuItem(currentPageScreenNum * menuItemsPerScreen);
+  byte y = getCurrentAppearance()->menuPageScreenTopOffset;
   byte i = 0;
-  while (menuItemTmp != nullptr && i < _menuItemsPerScreen) {
-    byte yText = y + getMenuItemInsetOffset() + _menuItemFont[_menuItemFontSize].baselineOffset * _textSize;
+  while (menuItemTmp != nullptr && i < menuItemsPerScreen) {
+    byte yText = y + getMenuItemInsetOffset() + _menuItemFont[getMenuItemFontSize()].baselineOffset * _textSize;
     byte yDraw = y + getMenuItemInsetOffset(true);
 
     printMenuItem(menuItemTmp, yText, yDraw, _menuForegroundColor);
 
     menuItemTmp = menuItemTmp->getMenuItemNext();
-    y += _menuItemHeight;
+    y += getCurrentAppearance()->menuItemHeight;
     i++;
   }
   memset(_valueString, '\0', GEM_STR_LEN - 1);
@@ -482,10 +520,12 @@ void GEM_adafruit_gfx::drawMenuPointer(bool clear) {
   if (_menuPageCurrent->itemsCount > 0) {
     GEMItem* menuItemTmp = _menuPageCurrent->getCurrentMenuItem();
     int pointerPosition = getCurrentItemTopOffset(false);
-    if (_menuPointerType == GEM_POINTER_DASH) {
-      _agfx.fillRect(0, _menuPageScreenTopOffset, 2 * _textSize, _agfx.height() - _menuPageScreenTopOffset, _menuBackgroundColor);
+    byte menuItemHeight = getCurrentAppearance()->menuItemHeight;
+    if (getCurrentAppearance()->menuPointerType == GEM_POINTER_DASH) {
+      byte menuPageScreenTopOffset = getCurrentAppearance()->menuPageScreenTopOffset;
+      _agfx.fillRect(0, menuPageScreenTopOffset, 2 * _textSize, _agfx.height() - menuPageScreenTopOffset, _menuBackgroundColor);
       if (menuItemTmp->readonly) {
-        for (byte i = 0; i < (_menuItemHeight - 1) / 2; i++) {
+        for (byte i = 0; i < (menuItemHeight - 1) / 2; i++) {
           _agfx.drawPixel(0, pointerPosition + i * 2, _menuForegroundColor);
           _agfx.drawPixel(1, pointerPosition + i * 2 + 1, _menuForegroundColor);
           if (_textSize > 1) {
@@ -494,22 +534,23 @@ void GEM_adafruit_gfx::drawMenuPointer(bool clear) {
           }
         }
       } else {
-        _agfx.fillRect(0, pointerPosition, 2 * _textSize, _menuItemHeight - 1, _menuForegroundColor);
+        _agfx.fillRect(0, pointerPosition, 2 * _textSize, menuItemHeight - 1, _menuForegroundColor);
       }
       if (clear) {
-        byte yText = pointerPosition + getMenuItemInsetOffset() + _menuItemFont[_menuItemFontSize].baselineOffset * _textSize;
+        byte yText = pointerPosition + getMenuItemInsetOffset() + _menuItemFont[getMenuItemFontSize()].baselineOffset * _textSize;
         byte yDraw = pointerPosition + getMenuItemInsetOffset(true);
-        _agfx.fillRect(5 * _textSize, pointerPosition - 1, _agfx.width() - 2, _menuItemHeight + 1, _menuBackgroundColor);
+        _agfx.fillRect(5 * _textSize, pointerPosition - 1, _agfx.width() - 2, menuItemHeight + 1, _menuBackgroundColor);
         printMenuItem(menuItemTmp, yText, yDraw, _menuForegroundColor);
       }
     } else {
-      byte yText = pointerPosition + getMenuItemInsetOffset() + _menuItemFont[_menuItemFontSize].baselineOffset * _textSize;
+      byte yText = pointerPosition + getMenuItemInsetOffset() + _menuItemFont[getMenuItemFontSize()].baselineOffset * _textSize;
       byte yDraw = pointerPosition + getMenuItemInsetOffset(true);
-      byte screensCount = (_menuPageCurrent->itemsCount % _menuItemsPerScreen == 0) ? _menuPageCurrent->itemsCount / _menuItemsPerScreen : _menuPageCurrent->itemsCount / _menuItemsPerScreen + 1;
-      _agfx.fillRect(0, pointerPosition - 1, _agfx.width() + (screensCount > 1 ? -2 : 0), _menuItemHeight + 1, clear ? _menuBackgroundColor : _menuForegroundColor);
+      byte menuItemsPerScreen = getMenuItemsPerScreen();
+      byte screensCount = (_menuPageCurrent->itemsCount % menuItemsPerScreen == 0) ? _menuPageCurrent->itemsCount / menuItemsPerScreen : _menuPageCurrent->itemsCount / menuItemsPerScreen + 1;
+      _agfx.fillRect(0, pointerPosition - 1, _agfx.width() + (screensCount > 1 ? -2 : 0), menuItemHeight + 1, clear ? _menuBackgroundColor : _menuForegroundColor);
       printMenuItem(menuItemTmp, yText, yDraw, clear ? _menuForegroundColor : _menuBackgroundColor);
       if (menuItemTmp->readonly) {
-        for (byte i = 0; i < (_menuItemHeight + 2) / 2; i++) {
+        for (byte i = 0; i < (menuItemHeight + 2) / 2; i++) {
           _agfx.drawPixel(0, pointerPosition + i * 2, _menuBackgroundColor);
           _agfx.drawPixel(1, pointerPosition + i * 2 - 1, _menuBackgroundColor);
           if (_textSize > 1) {
@@ -523,11 +564,13 @@ void GEM_adafruit_gfx::drawMenuPointer(bool clear) {
 }
 
 void GEM_adafruit_gfx::drawScrollbar() {
-  byte screensCount = (_menuPageCurrent->itemsCount % _menuItemsPerScreen == 0) ? _menuPageCurrent->itemsCount / _menuItemsPerScreen : _menuPageCurrent->itemsCount / _menuItemsPerScreen + 1;
+  byte menuItemsPerScreen = getMenuItemsPerScreen();
+  byte screensCount = (_menuPageCurrent->itemsCount % menuItemsPerScreen == 0) ? _menuPageCurrent->itemsCount / menuItemsPerScreen : _menuPageCurrent->itemsCount / menuItemsPerScreen + 1;
   if (screensCount > 1) {
-    byte currentScreenNum = _menuPageCurrent->currentItemNum / _menuItemsPerScreen;
-    byte scrollbarHeight = (_agfx.height() - _menuPageScreenTopOffset + 1) / screensCount;
-    byte scrollbarPosition = currentScreenNum * scrollbarHeight + _menuPageScreenTopOffset - 1;
+    byte currentScreenNum = _menuPageCurrent->currentItemNum / menuItemsPerScreen;
+    byte menuPageScreenTopOffset = getCurrentAppearance()->menuPageScreenTopOffset;
+    byte scrollbarHeight = (_agfx.height() - menuPageScreenTopOffset + 1) / screensCount;
+    byte scrollbarPosition = currentScreenNum * scrollbarHeight + menuPageScreenTopOffset - 1;
     _agfx.drawLine(_agfx.width() - 1, scrollbarPosition, _agfx.width() - 1, scrollbarPosition + scrollbarHeight, _menuForegroundColor);
   }
 }
@@ -535,7 +578,7 @@ void GEM_adafruit_gfx::drawScrollbar() {
 //====================== MENU ITEMS NAVIGATION
 
 void GEM_adafruit_gfx::nextMenuItem() {
-  if (_menuPointerType != GEM_POINTER_DASH) {
+  if (getCurrentAppearance()->menuPointerType != GEM_POINTER_DASH) {
     drawMenuPointer(true);
   }
   if (_menuPageCurrent->currentItemNum == _menuPageCurrent->itemsCount-1) {
@@ -543,7 +586,8 @@ void GEM_adafruit_gfx::nextMenuItem() {
   } else {
     _menuPageCurrent->currentItemNum++;
   }
-  bool redrawMenu = (_menuPageCurrent->itemsCount > _menuItemsPerScreen && _menuPageCurrent->currentItemNum % _menuItemsPerScreen == 0);
+  byte menuItemsPerScreen = getMenuItemsPerScreen();
+  bool redrawMenu = (_menuPageCurrent->itemsCount > menuItemsPerScreen && _menuPageCurrent->currentItemNum % menuItemsPerScreen == 0);
   if (redrawMenu) {
     drawMenu();
   } else {
@@ -552,10 +596,11 @@ void GEM_adafruit_gfx::nextMenuItem() {
 }
 
 void GEM_adafruit_gfx::prevMenuItem() {
-  if (_menuPointerType != GEM_POINTER_DASH) {
+  if (getCurrentAppearance()->menuPointerType != GEM_POINTER_DASH) {
     drawMenuPointer(true);
   }
-  bool redrawMenu = (_menuPageCurrent->itemsCount > _menuItemsPerScreen && _menuPageCurrent->currentItemNum % _menuItemsPerScreen == 0);
+  byte menuItemsPerScreen = getMenuItemsPerScreen();
+  bool redrawMenu = (_menuPageCurrent->itemsCount > menuItemsPerScreen && _menuPageCurrent->currentItemNum % menuItemsPerScreen == 0);
   if (_menuPageCurrent->currentItemNum == 0) {
     _menuPageCurrent->currentItemNum = _menuPageCurrent->itemsCount-1;
   } else {
@@ -607,7 +652,7 @@ void GEM_adafruit_gfx::enterEditValueMode() {
   
   GEMItem* menuItemTmp = _menuPageCurrent->getCurrentMenuItem();
   _editValueType = menuItemTmp->linkedType;
-  if ((_menuPointerType != GEM_POINTER_DASH) && (_editValueType != GEM_VAL_BOOL)) {
+  if ((getCurrentAppearance()->menuPointerType != GEM_POINTER_DASH) && (_editValueType != GEM_VAL_BOOL)) {
     drawMenuPointer(true);
   }
   switch (_editValueType) {
@@ -666,15 +711,17 @@ void GEM_adafruit_gfx::checkboxToggle() {
     }
     exitEditValue();
   } else {
-    uint16_t foreColor = (_menuPointerType == GEM_POINTER_DASH) ? _menuForegroundColor : _menuBackgroundColor;
-    uint16_t backColor = (_menuPointerType == GEM_POINTER_DASH) ? _menuBackgroundColor : _menuForegroundColor;
+    byte menuPointerType = getCurrentAppearance()->menuPointerType;
+    uint16_t foreColor = (menuPointerType == GEM_POINTER_DASH) ? _menuForegroundColor : _menuBackgroundColor;
+    uint16_t backColor = (menuPointerType == GEM_POINTER_DASH) ? _menuBackgroundColor : _menuForegroundColor;
     byte variant = _textSize > 1 ? 1 : 0;
+    byte menuValuesLeftOffset = getCurrentAppearance()->menuValuesLeftOffset;
     if (!checkboxValue) {
-      _agfx.fillRect(_menuValuesLeftOffset, topOffset, checkboxChecked[variant].width, checkboxChecked[variant].height, backColor);
-      drawSprite(_menuValuesLeftOffset, topOffset, checkboxChecked, foreColor);
+      _agfx.fillRect(menuValuesLeftOffset, topOffset, checkboxChecked[variant].width, checkboxChecked[variant].height, backColor);
+      drawSprite(menuValuesLeftOffset, topOffset, checkboxChecked, foreColor);
     } else {
-      _agfx.fillRect(_menuValuesLeftOffset, topOffset, checkboxUnchecked[variant].width, checkboxUnchecked[variant].height, backColor);
-      drawSprite(_menuValuesLeftOffset, topOffset, checkboxUnchecked, foreColor);
+      _agfx.fillRect(menuValuesLeftOffset, topOffset, checkboxUnchecked[variant].width, checkboxUnchecked[variant].height, backColor);
+      drawSprite(menuValuesLeftOffset, topOffset, checkboxUnchecked, foreColor);
     }
     _editValueMode = false;
   }
@@ -682,8 +729,8 @@ void GEM_adafruit_gfx::checkboxToggle() {
 
 void GEM_adafruit_gfx::clearValueVisibleRange() {
   int pointerPosition = getCurrentItemTopOffset(false);
-  byte cursorLeftOffset = _menuValuesLeftOffset;
-  _agfx.fillRect(cursorLeftOffset - 1, pointerPosition - 1, _agfx.width() - cursorLeftOffset - 1, _menuItemHeight + 1, _menuBackgroundColor);
+  byte cursorLeftOffset = getCurrentAppearance()->menuValuesLeftOffset;
+  _agfx.fillRect(cursorLeftOffset - 1, pointerPosition - 1, _agfx.width() - cursorLeftOffset - 1, getCurrentAppearance()->menuItemHeight + 1, _menuBackgroundColor);
 }
 
 void GEM_adafruit_gfx::initEditValueCursor() {
@@ -700,12 +747,13 @@ void GEM_adafruit_gfx::initEditValueCursor() {
 void GEM_adafruit_gfx::nextEditValueCursorPosition() {
   char chr = _valueString[_editValueVirtualCursorPosition];
   drawEditValueDigit(chr, true);
-  if ((_editValueCursorPosition != _menuItemValueLength - 1) && (_editValueCursorPosition != _editValueLength - 1) && (_valueString[_editValueCursorPosition] != '\0')) {
+  byte menuItemValueLength = getMenuItemValueLength();
+  if ((_editValueCursorPosition != menuItemValueLength - 1) && (_editValueCursorPosition != _editValueLength - 1) && (_valueString[_editValueCursorPosition] != '\0')) {
     _editValueCursorPosition++;
   }
   if ((_editValueVirtualCursorPosition != _editValueLength - 1) && (_valueString[_editValueVirtualCursorPosition] != '\0')) {
     _editValueVirtualCursorPosition++;
-    if (_editValueCursorPosition == _menuItemValueLength - 1) {
+    if (_editValueCursorPosition == menuItemValueLength - 1) {
       clearValueVisibleRange();
       printMenuItemValue(_valueString, 0, _editValueVirtualCursorPosition - _editValueCursorPosition);
     }
@@ -733,13 +781,15 @@ void GEM_adafruit_gfx::prevEditValueCursorPosition() {
 
 void GEM_adafruit_gfx::drawEditValueCursor(bool clear) {
   int pointerPosition = getCurrentItemTopOffset(false);
-  byte cursorLeftOffset = _menuValuesLeftOffset + _editValueCursorPosition * _menuItemFont[_menuItemFontSize].width * _textSize;
+  byte menuItemFontSize = getMenuItemFontSize();
+  byte menuValuesLeftOffset = getCurrentAppearance()->menuValuesLeftOffset;
+  byte cursorLeftOffset = menuValuesLeftOffset + _editValueCursorPosition * _menuItemFont[menuItemFontSize].width * _textSize;
   if (_editValueType == GEM_VAL_SELECT) {
-    _agfx.fillRect(cursorLeftOffset - 1, pointerPosition - 1, _agfx.width() - cursorLeftOffset - 1, _menuItemHeight + 1, clear ? _menuBackgroundColor : _menuForegroundColor);
+    _agfx.fillRect(cursorLeftOffset - 1, pointerPosition - 1, _agfx.width() - cursorLeftOffset - 1, getCurrentAppearance()->menuItemHeight + 1, clear ? _menuBackgroundColor : _menuForegroundColor);
   } else {
-    _agfx.fillRect(cursorLeftOffset - 1, pointerPosition - 1, _menuItemFont[_menuItemFontSize].width * _textSize + 1, _menuItemHeight + 1, clear ? _menuBackgroundColor : _menuForegroundColor);
-    byte yText = pointerPosition + getMenuItemInsetOffset() + _menuItemFont[_menuItemFontSize].baselineOffset * _textSize;
-    _agfx.setCursor(_menuValuesLeftOffset, yText);
+    _agfx.fillRect(cursorLeftOffset - 1, pointerPosition - 1, _menuItemFont[menuItemFontSize].width * _textSize + 1, getCurrentAppearance()->menuItemHeight + 1, clear ? _menuBackgroundColor : _menuForegroundColor);
+    byte yText = pointerPosition + getMenuItemInsetOffset() + _menuItemFont[menuItemFontSize].baselineOffset * _textSize;
+    _agfx.setCursor(menuValuesLeftOffset, yText);
   }
 }
 
@@ -834,8 +884,9 @@ void GEM_adafruit_gfx::drawEditValueDigit(byte code, bool clear) {
   uint16_t foreColor = (clear) ? _menuForegroundColor : _menuBackgroundColor;
   uint16_t backColor = (clear) ? _menuBackgroundColor : _menuForegroundColor;
   int pointerPosition = getCurrentItemTopOffset(false);
-  byte xText = _menuValuesLeftOffset + _editValueCursorPosition * _menuItemFont[_menuItemFontSize].width * _textSize;
-  byte yText = pointerPosition + getMenuItemInsetOffset() + _menuItemFont[_menuItemFontSize].baselineOffset * _textSize;
+  byte menuItemFontSize = getMenuItemFontSize();
+  byte xText = getCurrentAppearance()->menuValuesLeftOffset + _editValueCursorPosition * _menuItemFont[menuItemFontSize].width * _textSize;
+  byte yText = pointerPosition + getMenuItemInsetOffset() + _menuItemFont[menuItemFontSize].baselineOffset * _textSize;
   char chrNew = (char)code;
   if (chrNew != '\0') {
     _valueString[_editValueVirtualCursorPosition] = chrNew;
@@ -866,8 +917,8 @@ void GEM_adafruit_gfx::drawEditValueSelect() {
   _agfx.setTextColor(_menuBackgroundColor);
   
   int pointerPosition = getCurrentItemTopOffset(false);
-  byte yText = pointerPosition + getMenuItemInsetOffset() + _menuItemFont[_menuItemFontSize].baselineOffset * _textSize;
-  _agfx.setCursor(_menuValuesLeftOffset, yText);
+  byte yText = pointerPosition + getMenuItemInsetOffset() + _menuItemFont[getMenuItemFontSize()].baselineOffset * _textSize;
+  _agfx.setCursor(getCurrentAppearance()->menuValuesLeftOffset, yText);
   
   printMenuItemValue(select->getOptionNameByIndex(_valueSelectNum));
   drawSprite(_agfx.width() - 7 * _textSize, getCurrentItemTopOffset(true, true), selectArrows, _menuBackgroundColor);
@@ -909,7 +960,8 @@ void GEM_adafruit_gfx::saveEditValue() {
     }
     exitEditValue();
   } else {
-    exitEditValue(false);
+    // exitEditValue(false); // Can speed up work of Adafruit GFX version of GEM on Uno R3, but disabled to be in line with other GEM versions
+    exitEditValue();
   }
 }
 
@@ -924,7 +976,7 @@ void GEM_adafruit_gfx::exitEditValue(bool redrawMenu) {
   if (redrawMenu) {
     drawMenu();
   } else {
-    drawMenuPointer(_menuPointerType == GEM_POINTER_DASH);
+    drawMenuPointer(getCurrentAppearance()->menuPointerType == GEM_POINTER_DASH);
   }
 }
 

--- a/src/GEM_adafruit_gfx.cpp
+++ b/src/GEM_adafruit_gfx.cpp
@@ -50,8 +50,10 @@
 #define GEM_CHAR_CODE_DOT 46
 #define GEM_CHAR_CODE_SPACE 32
 #define GEM_CHAR_CODE_UNDERSCORE 95
-#define GEM_CHAR_CODE_LINE 124
 #define GEM_CHAR_CODE_TILDA 126
+#define GEM_CHAR_CODE_BANG 33
+#define GEM_CHAR_CODE_a 97
+#define GEM_CHAR_CODE_ACCENT 96
 
 // Sprite of the default GEM _splash screen (GEM logo v1)
 /*
@@ -794,22 +796,40 @@ void GEM_adafruit_gfx::drawEditValueCursor(bool clear) {
 }
 
 void GEM_adafruit_gfx::nextEditValueDigit() {
+  GEMItem* menuItemTmp = _menuPageCurrent->getCurrentMenuItem();
   char chr = _valueString[_editValueVirtualCursorPosition];
   byte code = (byte)chr;
   if (_editValueType == GEM_VAL_CHAR) {
-    switch (code) {
-      case 0:
-        code = GEM_CHAR_CODE_SPACE;
-        break;
-      case GEM_CHAR_CODE_TILDA:
-        code = GEM_CHAR_CODE_SPACE;
-        break;
-      case GEM_CHAR_CODE_LINE - 1:
-        code = GEM_CHAR_CODE_LINE + 1;
-        break;
-      default:
-        code++;
-        break;
+    if (menuItemTmp->adjustedAsciiOrder) {
+      switch (code) {
+        case 0:
+          code = GEM_CHAR_CODE_a;
+          break;
+        case GEM_CHAR_CODE_SPACE:
+          code = GEM_CHAR_CODE_a;
+          break;
+        case GEM_CHAR_CODE_ACCENT:
+          code = GEM_CHAR_CODE_SPACE;
+          break;
+        case GEM_CHAR_CODE_TILDA:
+          code = GEM_CHAR_CODE_BANG;
+          break;
+        default:
+          code++;
+          break;
+      }
+    } else {
+      switch (code) {
+        case 0:
+          code = GEM_CHAR_CODE_SPACE;
+          break;
+        case GEM_CHAR_CODE_TILDA:
+          code = GEM_CHAR_CODE_SPACE;
+          break;
+        default:
+          code++;
+          break;
+      }
     }
   } else {
     switch (code) {
@@ -837,22 +857,40 @@ void GEM_adafruit_gfx::nextEditValueDigit() {
 }
 
 void GEM_adafruit_gfx::prevEditValueDigit() {
+  GEMItem* menuItemTmp = _menuPageCurrent->getCurrentMenuItem();
   char chr = _valueString[_editValueVirtualCursorPosition];
   byte code = (byte)chr;
   if (_editValueType == GEM_VAL_CHAR) {
-    switch (code) {
-      case 0:
-        code = GEM_CHAR_CODE_TILDA;
-        break;
-      case GEM_CHAR_CODE_SPACE:
-        code = GEM_CHAR_CODE_TILDA;
-        break;
-      case GEM_CHAR_CODE_LINE + 1:
-        code = GEM_CHAR_CODE_LINE - 1;
-        break;
-      default:
-        code--;
-        break;
+    if (menuItemTmp->adjustedAsciiOrder) {
+      switch (code) {
+        case 0:
+          code = GEM_CHAR_CODE_TILDA;
+          break;
+        case GEM_CHAR_CODE_BANG:
+          code = GEM_CHAR_CODE_TILDA;
+          break;
+        case GEM_CHAR_CODE_a:
+          code = GEM_CHAR_CODE_SPACE;
+          break;
+        case GEM_CHAR_CODE_SPACE:
+          code = GEM_CHAR_CODE_ACCENT;
+          break;
+        default:
+          code--;
+          break;
+      }
+    } else {
+      switch (code) {
+        case 0:
+          code = GEM_CHAR_CODE_TILDA;
+          break;
+        case GEM_CHAR_CODE_SPACE:
+          code = GEM_CHAR_CODE_TILDA;
+          break;
+        default:
+          code--;
+          break;
+      }
     }
   } else {
     switch (code) {

--- a/src/GEM_adafruit_gfx.cpp
+++ b/src/GEM_adafruit_gfx.cpp
@@ -1002,7 +1002,7 @@ void GEM_adafruit_gfx::saveEditValue() {
     }
     exitEditValue();
   } else {
-    // exitEditValue(false); // Can speed up work of Adafruit GFX version of GEM on Uno R3, but disabled to be in line with other GEM versions
+    // exitEditValue(false); // Can speed up work of Adafruit GFX version of GEM on UNO R3, but disabled to be in line with other GEM versions
     exitEditValue();
   }
 }

--- a/src/GEM_adafruit_gfx.cpp
+++ b/src/GEM_adafruit_gfx.cpp
@@ -864,7 +864,7 @@ void GEM_adafruit_gfx::prevEditValueDigit() {
     if (menuItemTmp->adjustedAsciiOrder) {
       switch (code) {
         case 0:
-          code = GEM_CHAR_CODE_TILDA;
+          code = GEM_CHAR_CODE_ACCENT;
           break;
         case GEM_CHAR_CODE_BANG:
           code = GEM_CHAR_CODE_TILDA;

--- a/src/GEM_adafruit_gfx.h
+++ b/src/GEM_adafruit_gfx.h
@@ -139,6 +139,7 @@ class GEM_adafruit_gfx {
     GEM_adafruit_gfx& init();                                         // Init the menu (load necessary sprites into RAM of the SparkFun Graphic LCD Serial Backpack, display GEM splash screen, etc.)
     GEM_adafruit_gfx& reInit();                                       // Reinitialize the menu (apply GEM specific settings to AltSerialGraphicLCD library)
     GEM_adafruit_gfx& setMenuPageCurrent(GEMPage& menuPageCurrent);   // Set supplied menu page as current
+    GEMPage* getCurrentMenuPage();                                    // Get pointer to current menu page
 
     /* CONTEXT OPERATIONS */
 

--- a/src/GEM_adafruit_gfx.h
+++ b/src/GEM_adafruit_gfx.h
@@ -42,6 +42,7 @@
 #include <Adafruit_GFX.h>
 #include "fonts/TomThumbMono.h"
 #include "fonts/Fixed6x12.h"
+#include "GEMAppearance.h"
 #include "GEMPage.h"
 #include "GEMSelect.h"
 #include "constants.h"
@@ -114,6 +115,15 @@ class GEM_adafruit_gfx {
       default 86 (suitable for 128x64 screen with other variables at their default values)
     */
     GEM_adafruit_gfx(Adafruit_GFX& agfx_, byte menuPointerType_ = GEM_POINTER_ROW, byte menuItemsPerScreen_ = 5, byte menuItemHeight_ = 10, byte menuPageScreenTopOffset_ = 10, byte menuValuesLeftOffset_ = 86);
+    /*
+      @param 'agfx_' - reference to an object created with Adafruit GFX library and used for communication with display
+      @param 'appearance_' - object of type GEMAppearance
+    */
+    GEM_adafruit_gfx(Adafruit_GFX& agfx_, GEMAppearance appearance_);
+
+    /* APPEARANCE OPERATIONS */
+
+    GEM_adafruit_gfx& setAppearance(GEMAppearance appearance);        // Set appearance of the menu (can be overridden in GEMPage on per page basis)
 
     /* INIT OPERATIONS */
 
@@ -146,19 +156,17 @@ class GEM_adafruit_gfx {
                                                                       // Accepts GEM_KEY_NONE, GEM_KEY_UP, GEM_KEY_RIGHT, GEM_KEY_DOWN, GEM_KEY_LEFT, GEM_KEY_CANCEL, GEM_KEY_OK values
   private:
     Adafruit_GFX& _agfx;
-    byte _menuPointerType;
-    byte _menuItemsPerScreen;
-    byte _menuItemHeight;
-    byte _menuPageScreenTopOffset;
-    byte _menuValuesLeftOffset;
-    byte _menuItemFontSize;
+    GEMAppearance* _appearanceCurrent = nullptr;
+    GEMAppearance _appearance;
+    GEMAppearance* getCurrentAppearance();
+    byte getMenuItemsPerScreen();
+    byte getMenuItemFontSize();
     FontSizeAgfx _menuItemFont[2] = {{6,12,11},{4,6,6}};
     FontFamiliesAGFX _fontFamilies = {GEM_FONT_BIG, GEM_FONT_SMALL};
     byte _textSize = 1;
     bool _invertKeysDuringEdit = false;
-    byte _menuItemInsetOffset;
-    byte _menuItemTitleLength;
-    byte _menuItemValueLength;
+    byte getMenuItemTitleLength();
+    byte getMenuItemValueLength();
     Splash _splash;
     uint16_t _splashDelay = 1000;
     bool _enableVersion = true;

--- a/src/GEM_u8g2.cpp
+++ b/src/GEM_u8g2.cpp
@@ -120,20 +120,59 @@ static const unsigned char selectArrows_bits [] U8X8_PROGMEM = {
 
 GEM_u8g2::GEM_u8g2(U8G2& u8g2_, byte menuPointerType_, byte menuItemsPerScreen_, byte menuItemHeight_, byte menuPageScreenTopOffset_, byte menuValuesLeftOffset_)
   : _u8g2(u8g2_)
-  , _menuPointerType(menuPointerType_)
-  , _menuItemsPerScreen(menuItemsPerScreen_)
-  , _menuItemHeight(menuItemHeight_)
-  , _menuPageScreenTopOffset(menuPageScreenTopOffset_)
-  , _menuValuesLeftOffset(menuValuesLeftOffset_)
 {
-  _menuItemFontSize = _menuItemHeight >= 8 ? 0 : 1;
-  _menuItemInsetOffset = (_menuItemHeight - _menuItemFont[_menuItemFontSize].height) / 2;
+  _appearance.menuPointerType = menuPointerType_;
+  _appearance.menuItemsPerScreen = menuItemsPerScreen_;
+  _appearance.menuItemHeight = menuItemHeight_;
+  _appearance.menuPageScreenTopOffset = menuPageScreenTopOffset_;
+  _appearance.menuValuesLeftOffset = menuValuesLeftOffset_;
+  _appearanceCurrent = &_appearance;
   _splash = {logo_width, logo_height, logo_bits};
   clearContext();
   _editValueMode = false;
   _editValueCursorPosition = 0;
   memset(_valueString, '\0', GEM_STR_LEN - 1);
   _valueSelectNum = -1;
+}
+
+GEM_u8g2::GEM_u8g2(U8G2& u8g2_, GEMAppearance appearance_)
+  : _u8g2(u8g2_)
+  , _appearance(appearance_)
+{
+  _appearanceCurrent = &_appearance;
+  _splash = {logo_width, logo_height, logo_bits};
+  clearContext();
+  _editValueMode = false;
+  _editValueCursorPosition = 0;
+  memset(_valueString, '\0', GEM_STR_LEN - 1);
+  _valueSelectNum = -1;
+}
+
+//====================== APPEARANCE OPERATIONS
+
+GEM_u8g2& GEM_u8g2::setAppearance(GEMAppearance appearance) {
+  _appearance = appearance;
+  return *this;
+}
+
+GEMAppearance* GEM_u8g2::getCurrentAppearance() {
+  return (_menuPageCurrent != nullptr && _menuPageCurrent->_appearance != nullptr) ? _menuPageCurrent->_appearance : &_appearance;
+}
+
+byte GEM_u8g2::getMenuItemsPerScreen() {
+  return getCurrentAppearance()->menuItemsPerScreen == GEM_ITEMS_COUNT_AUTO ? (_u8g2.getDisplayHeight() - getCurrentAppearance()->menuPageScreenTopOffset) / getCurrentAppearance()->menuItemHeight : getCurrentAppearance()->menuItemsPerScreen;
+}
+
+byte GEM_u8g2::getMenuItemFontSize() {
+  return getCurrentAppearance()->menuItemHeight >= 8 ? 0 : 1;
+}
+
+byte GEM_u8g2::getMenuItemTitleLength() {
+  return (getCurrentAppearance()->menuValuesLeftOffset - 5) / _menuItemFont[getMenuItemFontSize()].width;
+}
+
+byte GEM_u8g2::getMenuItemValueLength() {
+  return (_u8g2.getDisplayWidth() - getCurrentAppearance()->menuValuesLeftOffset - 6) / _menuItemFont[getMenuItemFontSize()].width;
 }
 
 //====================== INIT OPERATIONS
@@ -174,12 +213,6 @@ GEM_u8g2& GEM_u8g2::init() {
   _u8g2.clear();
   _u8g2.setDrawColor(1);
   _u8g2.setFontPosTop();
-  
-  _menuItemTitleLength = (_menuValuesLeftOffset - 5) / _menuItemFont[_menuItemFontSize].width;
-  _menuItemValueLength = (_u8g2.getDisplayWidth() - _menuValuesLeftOffset - 6) / _menuItemFont[_menuItemFontSize].width;
-  if (_menuItemsPerScreen == GEM_ITEMS_COUNT_AUTO) {
-    _menuItemsPerScreen = (_u8g2.getDisplayHeight() - _menuPageScreenTopOffset) / _menuItemHeight;
-  }
 
   if (_splashDelay > 0) {
 
@@ -263,7 +296,7 @@ void GEM_u8g2::drawTitleBar() {
  _u8g2.setFont(_fontFamilies.small);
  _u8g2.setCursor(5, 0);
  _u8g2.print(_menuPageCurrent->title);
- _u8g2.setFont(_menuItemFontSize ? _fontFamilies.small : _fontFamilies.big);
+ _u8g2.setFont(getMenuItemFontSize() ? _fontFamilies.small : _fontFamilies.big);
 }
 
 void GEM_u8g2::printMenuItemString(const char* str, byte num, byte startPos) {
@@ -301,116 +334,122 @@ void GEM_u8g2::printMenuItemString(const char* str, byte num, byte startPos) {
 }
 
 void GEM_u8g2::printMenuItemTitle(const char* str, int offset) {
-  printMenuItemString(str, _menuItemTitleLength + offset);
+  printMenuItemString(str, getMenuItemTitleLength() + offset);
 }
 
 void GEM_u8g2::printMenuItemValue(const char* str, int offset, byte startPos) {
-  printMenuItemString(str, _menuItemValueLength + offset, startPos);
+  printMenuItemString(str, getMenuItemValueLength() + offset, startPos);
 }
 
 void GEM_u8g2::printMenuItemFull(const char* str, int offset) {
-  printMenuItemString(str, _menuItemTitleLength + _menuItemValueLength + offset);
+  printMenuItemString(str, getMenuItemTitleLength() + getMenuItemValueLength() + offset);
 }
 
 byte GEM_u8g2::getMenuItemInsetOffset(bool forSprite) {
-  return _menuItemInsetOffset + (forSprite ? (_menuItemFontSize ? -1 : 0) : -1 ); // With additional offset for 6x8 sprites to compensate for smaller font size
+  byte menuItemFontSize = getMenuItemFontSize();
+  byte menuItemInsetOffset = (getCurrentAppearance()->menuItemHeight - _menuItemFont[menuItemFontSize].height) / 2;
+  return menuItemInsetOffset + (forSprite ? (menuItemFontSize ? -1 : 0) : -1 ); // With additional offset for 6x8 sprites to compensate for smaller font size
 }
 
 byte GEM_u8g2::getCurrentItemTopOffset(bool withInsetOffset, bool forSprite) {
-  return (_menuPageCurrent->currentItemNum % _menuItemsPerScreen) * _menuItemHeight + _menuPageScreenTopOffset + (withInsetOffset ? getMenuItemInsetOffset(forSprite) : 0);
+  return (_menuPageCurrent->currentItemNum % getMenuItemsPerScreen()) * getCurrentAppearance()->menuItemHeight + getCurrentAppearance()->menuPageScreenTopOffset + (withInsetOffset ? getMenuItemInsetOffset(forSprite) : 0);
 }
 
 void GEM_u8g2::printMenuItems() {
-  byte currentPageScreenNum = _menuPageCurrent->currentItemNum / _menuItemsPerScreen;
-  GEMItem* menuItemTmp = _menuPageCurrent->getMenuItem(currentPageScreenNum * _menuItemsPerScreen);
-  byte y = _menuPageScreenTopOffset;
+  byte menuItemsPerScreen = getMenuItemsPerScreen();
+  byte currentPageScreenNum = _menuPageCurrent->currentItemNum / menuItemsPerScreen;
+  GEMItem* menuItemTmp = _menuPageCurrent->getMenuItem(currentPageScreenNum * menuItemsPerScreen);
+  byte y = getCurrentAppearance()->menuPageScreenTopOffset;
   byte i = 0;
   char valueStringTmp[GEM_STR_LEN];
-  while (menuItemTmp != nullptr && i < _menuItemsPerScreen) {
+  while (menuItemTmp != nullptr && i < menuItemsPerScreen) {
     byte yText = y + getMenuItemInsetOffset();
     byte yDraw = y + getMenuItemInsetOffset(true);
     switch (menuItemTmp->type) {
       case GEM_ITEM_VAL:
-        _u8g2.setCursor(5, yText);
-        if (menuItemTmp->readonly) {
-          printMenuItemTitle(menuItemTmp->title, -1);
-          _u8g2.print("^");
-        } else {
-          printMenuItemTitle(menuItemTmp->title);
-        }
-        
-        _u8g2.setCursor(_menuValuesLeftOffset, yText);
-        switch (menuItemTmp->linkedType) {
-          case GEM_VAL_INTEGER:
-            if (_editValueMode && menuItemTmp == _menuPageCurrent->getCurrentMenuItem()) {
-              printMenuItemValue(_valueString, 0, _editValueVirtualCursorPosition - _editValueCursorPosition);
-              drawEditValueCursor();
-            } else {
-              itoa(*(int*)menuItemTmp->linkedVariable, valueStringTmp, 10);
-              printMenuItemValue(valueStringTmp);
-            }
-            break;
-          case GEM_VAL_BYTE:
-            if (_editValueMode && menuItemTmp == _menuPageCurrent->getCurrentMenuItem()) {
-              printMenuItemValue(_valueString, 0, _editValueVirtualCursorPosition - _editValueCursorPosition);
-              drawEditValueCursor();
-            } else {
-              itoa(*(byte*)menuItemTmp->linkedVariable, valueStringTmp, 10);
-              printMenuItemValue(valueStringTmp);
-            }
-            break;
-          case GEM_VAL_CHAR:
-            if (_editValueMode && menuItemTmp == _menuPageCurrent->getCurrentMenuItem()) {
-              printMenuItemValue(_valueString, 0, _editValueVirtualCursorPosition - _editValueCursorPosition);
-              drawEditValueCursor();
-            } else {
-              printMenuItemValue((char*)menuItemTmp->linkedVariable);
-            }
-            break;
-          case GEM_VAL_BOOL:
-            if (*(bool*)menuItemTmp->linkedVariable) {
-              _u8g2.drawXBMP(_menuValuesLeftOffset, yDraw, checkboxChecked_width, checkboxChecked_height, checkboxChecked_bits);
-            } else {
-              _u8g2.drawXBMP(_menuValuesLeftOffset, yDraw, checkboxUnchecked_width, checkboxUnchecked_height, checkboxUnchecked_bits);
-            }
-            break;
-          case GEM_VAL_SELECT:
-            {
-              GEMSelect* select = menuItemTmp->select;
+        {
+          _u8g2.setCursor(5, yText);
+          if (menuItemTmp->readonly) {
+            printMenuItemTitle(menuItemTmp->title, -1);
+            _u8g2.print("^");
+          } else {
+            printMenuItemTitle(menuItemTmp->title);
+          }
+
+          byte menuValuesLeftOffset = getCurrentAppearance()->menuValuesLeftOffset;
+          _u8g2.setCursor(menuValuesLeftOffset, yText);
+          switch (menuItemTmp->linkedType) {
+            case GEM_VAL_INTEGER:
               if (_editValueMode && menuItemTmp == _menuPageCurrent->getCurrentMenuItem()) {
-                printMenuItemValue(select->getOptionNameByIndex(_valueSelectNum));
-                _u8g2.drawXBMP(_u8g2.getDisplayWidth() - 7, yDraw, selectArrows_width, selectArrows_height, selectArrows_bits);
+                printMenuItemValue(_valueString, 0, _editValueVirtualCursorPosition - _editValueCursorPosition);
                 drawEditValueCursor();
               } else {
-                printMenuItemValue(select->getSelectedOptionName(menuItemTmp->linkedVariable));
-                _u8g2.drawXBMP(_u8g2.getDisplayWidth() - 7, yDraw, selectArrows_width, selectArrows_height, selectArrows_bits);
+                itoa(*(int*)menuItemTmp->linkedVariable, valueStringTmp, 10);
+                printMenuItemValue(valueStringTmp);
               }
-            }
-            break;
-          #ifdef GEM_SUPPORT_FLOAT_EDIT
-          case GEM_VAL_FLOAT:
-            if (_editValueMode && menuItemTmp == _menuPageCurrent->getCurrentMenuItem()) {
-              printMenuItemValue(_valueString, 0, _editValueVirtualCursorPosition - _editValueCursorPosition);
-              drawEditValueCursor();
-            } else {
-              // sprintf(valueStringTmp,"%.6f", *(float*)menuItemTmp->linkedVariable); // May work for non-AVR boards
-              dtostrf(*(float*)menuItemTmp->linkedVariable, menuItemTmp->precision + 1, menuItemTmp->precision, valueStringTmp);
-              printMenuItemValue(valueStringTmp);
-            }
-            break;
-          case GEM_VAL_DOUBLE:
-            if (_editValueMode && menuItemTmp == _menuPageCurrent->getCurrentMenuItem()) {
-              printMenuItemValue(_valueString, 0, _editValueVirtualCursorPosition - _editValueCursorPosition);
-              drawEditValueCursor();
-            } else {
-              // sprintf(valueStringTmp,"%.6f", *(double*)menuItemTmp->linkedVariable); // May work for non-AVR boards
-              dtostrf(*(double*)menuItemTmp->linkedVariable, menuItemTmp->precision + 1, menuItemTmp->precision, valueStringTmp);
-              printMenuItemValue(valueStringTmp);
-            }
-            break;
-          #endif
+              break;
+            case GEM_VAL_BYTE:
+              if (_editValueMode && menuItemTmp == _menuPageCurrent->getCurrentMenuItem()) {
+                printMenuItemValue(_valueString, 0, _editValueVirtualCursorPosition - _editValueCursorPosition);
+                drawEditValueCursor();
+              } else {
+                itoa(*(byte*)menuItemTmp->linkedVariable, valueStringTmp, 10);
+                printMenuItemValue(valueStringTmp);
+              }
+              break;
+            case GEM_VAL_CHAR:
+              if (_editValueMode && menuItemTmp == _menuPageCurrent->getCurrentMenuItem()) {
+                printMenuItemValue(_valueString, 0, _editValueVirtualCursorPosition - _editValueCursorPosition);
+                drawEditValueCursor();
+              } else {
+                printMenuItemValue((char*)menuItemTmp->linkedVariable);
+              }
+              break;
+            case GEM_VAL_BOOL:
+              if (*(bool*)menuItemTmp->linkedVariable) {
+                _u8g2.drawXBMP(menuValuesLeftOffset, yDraw, checkboxChecked_width, checkboxChecked_height, checkboxChecked_bits);
+              } else {
+                _u8g2.drawXBMP(menuValuesLeftOffset, yDraw, checkboxUnchecked_width, checkboxUnchecked_height, checkboxUnchecked_bits);
+              }
+              break;
+            case GEM_VAL_SELECT:
+              {
+                GEMSelect* select = menuItemTmp->select;
+                if (_editValueMode && menuItemTmp == _menuPageCurrent->getCurrentMenuItem()) {
+                  printMenuItemValue(select->getOptionNameByIndex(_valueSelectNum));
+                  _u8g2.drawXBMP(_u8g2.getDisplayWidth() - 7, yDraw, selectArrows_width, selectArrows_height, selectArrows_bits);
+                  drawEditValueCursor();
+                } else {
+                  printMenuItemValue(select->getSelectedOptionName(menuItemTmp->linkedVariable));
+                  _u8g2.drawXBMP(_u8g2.getDisplayWidth() - 7, yDraw, selectArrows_width, selectArrows_height, selectArrows_bits);
+                }
+              }
+              break;
+            #ifdef GEM_SUPPORT_FLOAT_EDIT
+            case GEM_VAL_FLOAT:
+              if (_editValueMode && menuItemTmp == _menuPageCurrent->getCurrentMenuItem()) {
+                printMenuItemValue(_valueString, 0, _editValueVirtualCursorPosition - _editValueCursorPosition);
+                drawEditValueCursor();
+              } else {
+                // sprintf(valueStringTmp,"%.6f", *(float*)menuItemTmp->linkedVariable); // May work for non-AVR boards
+                dtostrf(*(float*)menuItemTmp->linkedVariable, menuItemTmp->precision + 1, menuItemTmp->precision, valueStringTmp);
+                printMenuItemValue(valueStringTmp);
+              }
+              break;
+            case GEM_VAL_DOUBLE:
+              if (_editValueMode && menuItemTmp == _menuPageCurrent->getCurrentMenuItem()) {
+                printMenuItemValue(_valueString, 0, _editValueVirtualCursorPosition - _editValueCursorPosition);
+                drawEditValueCursor();
+              } else {
+                // sprintf(valueStringTmp,"%.6f", *(double*)menuItemTmp->linkedVariable); // May work for non-AVR boards
+                dtostrf(*(double*)menuItemTmp->linkedVariable, menuItemTmp->precision + 1, menuItemTmp->precision, valueStringTmp);
+                printMenuItemValue(valueStringTmp);
+              }
+              break;
+            #endif
+          }
+          break;
         }
-        break;
       case GEM_ITEM_LINK:
         _u8g2.setCursor(5, yText);
         if (menuItemTmp->readonly) {
@@ -437,7 +476,7 @@ void GEM_u8g2::printMenuItems() {
         break;
     }
     menuItemTmp = menuItemTmp->getMenuItemNext();
-    y += _menuItemHeight;
+    y += getCurrentAppearance()->menuItemHeight;
     i++;
   }
   memset(valueStringTmp, '\0', GEM_STR_LEN - 1);
@@ -447,22 +486,23 @@ void GEM_u8g2::drawMenuPointer() {
   if (_menuPageCurrent->itemsCount > 0) {
     GEMItem* menuItemTmp = _menuPageCurrent->getCurrentMenuItem();
     int pointerPosition = getCurrentItemTopOffset(false);
-    if (_menuPointerType == GEM_POINTER_DASH) {
+    byte menuItemHeight = getCurrentAppearance()->menuItemHeight;
+    if (getCurrentAppearance()->menuPointerType == GEM_POINTER_DASH) {
       if (menuItemTmp->readonly) {
-        for (byte i = 0; i < (_menuItemHeight - 1) / 2; i++) {
+        for (byte i = 0; i < (menuItemHeight - 1) / 2; i++) {
           _u8g2.drawPixel(0, pointerPosition + i * 2);
           _u8g2.drawPixel(1, pointerPosition + i * 2 + 1);
         }
       } else {
-        _u8g2.drawBox(0, pointerPosition, 2, _menuItemHeight - 1);
+        _u8g2.drawBox(0, pointerPosition, 2, menuItemHeight - 1);
       }
     } else if (!_editValueMode) {
       _u8g2.setDrawColor(2);
-      _u8g2.drawBox(0, pointerPosition - 1, _u8g2.getDisplayWidth() - 2, _menuItemHeight + 1);
+      _u8g2.drawBox(0, pointerPosition - 1, _u8g2.getDisplayWidth() - 2, menuItemHeight + 1);
       _u8g2.setDrawColor(1);
       if (menuItemTmp->readonly) {
         _u8g2.setDrawColor(0);
-        for (byte i = 0; i < (_menuItemHeight + 2) / 2; i++) {
+        for (byte i = 0; i < (menuItemHeight + 2) / 2; i++) {
           _u8g2.drawPixel(0, pointerPosition + i * 2);
           _u8g2.drawPixel(1, pointerPosition + i * 2 - 1);
         }
@@ -473,11 +513,13 @@ void GEM_u8g2::drawMenuPointer() {
 }
 
 void GEM_u8g2::drawScrollbar() {
-  byte screensCount = (_menuPageCurrent->itemsCount % _menuItemsPerScreen == 0) ? _menuPageCurrent->itemsCount / _menuItemsPerScreen : _menuPageCurrent->itemsCount / _menuItemsPerScreen + 1;
+  byte menuItemsPerScreen = getMenuItemsPerScreen();
+  byte screensCount = (_menuPageCurrent->itemsCount % menuItemsPerScreen == 0) ? _menuPageCurrent->itemsCount / menuItemsPerScreen : _menuPageCurrent->itemsCount / menuItemsPerScreen + 1;
   if (screensCount > 1) {
-    byte currentScreenNum = _menuPageCurrent->currentItemNum / _menuItemsPerScreen;
-    byte scrollbarHeight = (_u8g2.getDisplayHeight() - _menuPageScreenTopOffset + 1) / screensCount;
-    byte scrollbarPosition = currentScreenNum * scrollbarHeight + _menuPageScreenTopOffset - 1;
+    byte currentScreenNum = _menuPageCurrent->currentItemNum / menuItemsPerScreen;
+    byte menuPageScreenTopOffset = getCurrentAppearance()->menuPageScreenTopOffset;
+    byte scrollbarHeight = (_u8g2.getDisplayHeight() - menuPageScreenTopOffset + 1) / screensCount;
+    byte scrollbarPosition = currentScreenNum * scrollbarHeight + menuPageScreenTopOffset - 1;
     _u8g2.drawLine(_u8g2.getDisplayWidth() - 1, scrollbarPosition, _u8g2.getDisplayWidth() - 1, scrollbarPosition + scrollbarHeight);
   }
 }
@@ -607,7 +649,7 @@ void GEM_u8g2::initEditValueCursor() {
 }
 
 void GEM_u8g2::nextEditValueCursorPosition() {
-  if ((_editValueCursorPosition != _menuItemValueLength - 1) && (_editValueCursorPosition != _editValueLength - 1) && (_valueString[_editValueCursorPosition] != '\0')) {
+  if ((_editValueCursorPosition != getMenuItemValueLength() - 1) && (_editValueCursorPosition != _editValueLength - 1) && (_valueString[_editValueCursorPosition] != '\0')) {
     _editValueCursorPosition++;
   }
   if ((_editValueVirtualCursorPosition != _editValueLength - 1) && (_valueString[_editValueVirtualCursorPosition] != '\0')) {
@@ -628,12 +670,13 @@ void GEM_u8g2::prevEditValueCursorPosition() {
 
 void GEM_u8g2::drawEditValueCursor() {
   int pointerPosition = getCurrentItemTopOffset(false);
-  byte cursorLeftOffset = _menuValuesLeftOffset + _editValueCursorPosition * _menuItemFont[_menuItemFontSize].width;
+  byte menuItemFontSize = getMenuItemFontSize();
+  byte cursorLeftOffset = getCurrentAppearance()->menuValuesLeftOffset + _editValueCursorPosition * _menuItemFont[menuItemFontSize].width;
   _u8g2.setDrawColor(2);
   if (_editValueType == GEM_VAL_SELECT) {
-    _u8g2.drawBox(cursorLeftOffset - 1, pointerPosition - 1, _u8g2.getDisplayWidth() - cursorLeftOffset - 1, _menuItemHeight + 1);
+    _u8g2.drawBox(cursorLeftOffset - 1, pointerPosition - 1, _u8g2.getDisplayWidth() - cursorLeftOffset - 1, getCurrentAppearance()->menuItemHeight + 1);
   } else {
-    _u8g2.drawBox(cursorLeftOffset - 1, pointerPosition - 1, _menuItemFont[_menuItemFontSize].width + 1, _menuItemHeight + 1);
+    _u8g2.drawBox(cursorLeftOffset - 1, pointerPosition - 1, _menuItemFont[menuItemFontSize].width + 1, getCurrentAppearance()->menuItemHeight + 1);
   }
   _u8g2.setDrawColor(1);
 }

--- a/src/GEM_u8g2.cpp
+++ b/src/GEM_u8g2.cpp
@@ -773,7 +773,7 @@ void GEM_u8g2::prevEditValueDigit() {
     if (menuItemTmp->adjustedAsciiOrder) {
       switch (code) {
         case 0:
-          code = GEM_CHAR_CODE_TILDA;
+          code = GEM_CHAR_CODE_ACCENT;
           break;
         case GEM_CHAR_CODE_BANG:
           code = GEM_CHAR_CODE_TILDA;

--- a/src/GEM_u8g2.cpp
+++ b/src/GEM_u8g2.cpp
@@ -50,8 +50,10 @@
 #define GEM_CHAR_CODE_DOT 46
 #define GEM_CHAR_CODE_SPACE 32
 #define GEM_CHAR_CODE_UNDERSCORE 95
-#define GEM_CHAR_CODE_LINE 124
 #define GEM_CHAR_CODE_TILDA 126
+#define GEM_CHAR_CODE_BANG 33
+#define GEM_CHAR_CODE_a 97
+#define GEM_CHAR_CODE_ACCENT 96
 /*
 // WIP for Cyrillic values support
 #define GEM_CHAR_CODE_CYR_YO 1025
@@ -682,40 +684,61 @@ void GEM_u8g2::drawEditValueCursor() {
 }
 
 void GEM_u8g2::nextEditValueDigit() {
+  GEMItem* menuItemTmp = _menuPageCurrent->getCurrentMenuItem();
   char chr = _valueString[_editValueVirtualCursorPosition];
   byte code = (byte)chr;
   if (_editValueType == GEM_VAL_CHAR) {
-    switch (code) {
-      case 0:
-        code = GEM_CHAR_CODE_SPACE;
-        break;
-      case GEM_CHAR_CODE_TILDA:
-        code = GEM_CHAR_CODE_SPACE;
-        break;
-      /*
-      // WIP for Cyrillic values support
-      case GEM_CHAR_CODE_TILDA:
-        code = _cyrillicEnabled ? GEM_CHAR_CODE_CYR_A : GEM_CHAR_CODE_SPACE;
-        break;
-      case GEM_CHAR_CODE_CYR_YA_SM:
-        code = GEM_CHAR_CODE_SPACE;
-        break;
-      case GEM_CHAR_CODE_CYR_E:
-        code = GEM_CHAR_CODE_CYR_YO;
-        break;
-      case GEM_CHAR_CODE_CYR_YO:
-        code = GEM_CHAR_CODE_CYR_E + 1;
-        break;
-      case GEM_CHAR_CODE_CYR_E_SM:
-        code = GEM_CHAR_CODE_CYR_YO_SM;
-        break;
-      case GEM_CHAR_CODE_CYR_YO_SM:
-        code = GEM_CHAR_CODE_CYR_E_SM + 1;
-        break;
-      */
-      default:
-        code++;
-        break;
+    if (menuItemTmp->adjustedAsciiOrder) {
+      switch (code) {
+        case 0:
+          code = GEM_CHAR_CODE_a;
+          break;
+        case GEM_CHAR_CODE_SPACE:
+          code = GEM_CHAR_CODE_a;
+          break;
+        case GEM_CHAR_CODE_ACCENT:
+          code = GEM_CHAR_CODE_SPACE;
+          break;
+        case GEM_CHAR_CODE_TILDA:
+          code = GEM_CHAR_CODE_BANG;
+          break;
+        default:
+          code++;
+          break;
+      }
+    } else {
+      switch (code) {
+        case 0:
+          code = GEM_CHAR_CODE_SPACE;
+          break;
+        case GEM_CHAR_CODE_TILDA:
+          code = GEM_CHAR_CODE_SPACE;
+          break;
+        /*
+        // WIP for Cyrillic values support
+        case GEM_CHAR_CODE_TILDA:
+          code = _cyrillicEnabled ? GEM_CHAR_CODE_CYR_A : GEM_CHAR_CODE_SPACE;
+          break;
+        case GEM_CHAR_CODE_CYR_YA_SM:
+          code = GEM_CHAR_CODE_SPACE;
+          break;
+        case GEM_CHAR_CODE_CYR_E:
+          code = GEM_CHAR_CODE_CYR_YO;
+          break;
+        case GEM_CHAR_CODE_CYR_YO:
+          code = GEM_CHAR_CODE_CYR_E + 1;
+          break;
+        case GEM_CHAR_CODE_CYR_E_SM:
+          code = GEM_CHAR_CODE_CYR_YO_SM;
+          break;
+        case GEM_CHAR_CODE_CYR_YO_SM:
+          code = GEM_CHAR_CODE_CYR_E_SM + 1;
+          break;
+        */
+        default:
+          code++;
+          break;
+      }
     }
   } else {
     switch (code) {
@@ -743,43 +766,64 @@ void GEM_u8g2::nextEditValueDigit() {
 }
 
 void GEM_u8g2::prevEditValueDigit() {
+  GEMItem* menuItemTmp = _menuPageCurrent->getCurrentMenuItem();
   char chr = _valueString[_editValueVirtualCursorPosition];
   byte code = (byte)chr;
   if (_editValueType == GEM_VAL_CHAR) {
-    switch (code) {
-      case 0:
-        code = GEM_CHAR_CODE_TILDA;
-        break;
-      case GEM_CHAR_CODE_SPACE:
-        code = GEM_CHAR_CODE_TILDA;
-        break;
-      /*
-      // WIP for Cyrillic values support
-      case 0:
-        code = _cyrillicEnabled ? GEM_CHAR_CODE_CYR_YA_SM : GEM_CHAR_CODE_TILDA;
-        break;
-      case GEM_CHAR_CODE_SPACE:
-        code = _cyrillicEnabled ? GEM_CHAR_CODE_CYR_YA_SM : GEM_CHAR_CODE_TILDA;
-        break;
-      case GEM_CHAR_CODE_CYR_A:
-        code = GEM_CHAR_CODE_TILDA;
-        break;
-      case GEM_CHAR_CODE_CYR_E + 1:
-        code = GEM_CHAR_CODE_CYR_YO;
-        break;
-      case GEM_CHAR_CODE_CYR_YO:
-        code = GEM_CHAR_CODE_CYR_E;
-        break;
-      case GEM_CHAR_CODE_CYR_E_SM + 1:
-        code = GEM_CHAR_CODE_CYR_YO_SM;
-        break;
-      case GEM_CHAR_CODE_CYR_YO_SM:
-        code = GEM_CHAR_CODE_CYR_E_SM;
-        break;
-      */
-      default:
-        code--;
-        break;
+    if (menuItemTmp->adjustedAsciiOrder) {
+      switch (code) {
+        case 0:
+          code = GEM_CHAR_CODE_TILDA;
+          break;
+        case GEM_CHAR_CODE_BANG:
+          code = GEM_CHAR_CODE_TILDA;
+          break;
+        case GEM_CHAR_CODE_a:
+          code = GEM_CHAR_CODE_SPACE;
+          break;
+        case GEM_CHAR_CODE_SPACE:
+          code = GEM_CHAR_CODE_ACCENT;
+          break;
+        default:
+          code--;
+          break;
+      }
+    } else {
+      switch (code) {
+        case 0:
+          code = GEM_CHAR_CODE_TILDA;
+          break;
+        case GEM_CHAR_CODE_SPACE:
+          code = GEM_CHAR_CODE_TILDA;
+          break;
+        /*
+        // WIP for Cyrillic values support
+        case 0:
+          code = _cyrillicEnabled ? GEM_CHAR_CODE_CYR_YA_SM : GEM_CHAR_CODE_TILDA;
+          break;
+        case GEM_CHAR_CODE_SPACE:
+          code = _cyrillicEnabled ? GEM_CHAR_CODE_CYR_YA_SM : GEM_CHAR_CODE_TILDA;
+          break;
+        case GEM_CHAR_CODE_CYR_A:
+          code = GEM_CHAR_CODE_TILDA;
+          break;
+        case GEM_CHAR_CODE_CYR_E + 1:
+          code = GEM_CHAR_CODE_CYR_YO;
+          break;
+        case GEM_CHAR_CODE_CYR_YO:
+          code = GEM_CHAR_CODE_CYR_E;
+          break;
+        case GEM_CHAR_CODE_CYR_E_SM + 1:
+          code = GEM_CHAR_CODE_CYR_YO_SM;
+          break;
+        case GEM_CHAR_CODE_CYR_YO_SM:
+          code = GEM_CHAR_CODE_CYR_E_SM;
+          break;
+        */
+        default:
+          code--;
+          break;
+      }
     }
   } else {
     switch (code) {

--- a/src/GEM_u8g2.cpp
+++ b/src/GEM_u8g2.cpp
@@ -270,6 +270,10 @@ GEM_u8g2& GEM_u8g2::setMenuPageCurrent(GEMPage& menuPageCurrent) {
   return *this;
 }
 
+GEMPage* GEM_u8g2::getCurrentMenuPage() {
+  return _menuPageCurrent;
+}
+
 //====================== CONTEXT OPERATIONS
 
 GEM_u8g2& GEM_u8g2::clearContext() {

--- a/src/GEM_u8g2.h
+++ b/src/GEM_u8g2.h
@@ -40,6 +40,7 @@
 #ifdef GEM_ENABLE_U8G2_VERSION
 
 #include <U8g2lib.h>
+#include "GEMAppearance.h"
 #include "GEMPage.h"
 #include "GEMSelect.h"
 #include "constants.h"
@@ -113,7 +114,16 @@ class GEM_u8g2 {
       default 86 (suitable for 128x64 screen with other variables at their default values)
     */
     GEM_u8g2(U8G2& u8g2_, byte menuPointerType_ = GEM_POINTER_ROW, byte menuItemsPerScreen_ = 5, byte menuItemHeight_ = 10, byte menuPageScreenTopOffset_ = 10, byte menuValuesLeftOffset_ = 86);
+    /*
+      @param 'u8g2_' - reference to an object created with U8g2 library and used for communication with LCD
+      @param 'appearance_' - object of type GEMAppearance
+    */
+    GEM_u8g2(U8G2& u8g2_, GEMAppearance appearance_);
 
+    /* APPEARANCE OPERATIONS */
+
+    GEM_u8g2& setAppearance(GEMAppearance appearance);        // Set appearance of the menu (can be overridden in GEMPage on per page basis)
+    
     /* INIT OPERATIONS */
 
     GEM_u8g2& setSplash(byte width, byte height, const unsigned char *image); // Set custom XBM image displayed as the splash screen when GEM is being initialized. Should be called before GEM_u8g2::init().
@@ -141,19 +151,17 @@ class GEM_u8g2 {
                                                               // Accepts GEM_KEY_NONE, GEM_KEY_UP, GEM_KEY_RIGHT, GEM_KEY_DOWN, GEM_KEY_LEFT, GEM_KEY_CANCEL, GEM_KEY_OK values
   private:
     U8G2& _u8g2;
-    byte _menuPointerType;
-    byte _menuItemsPerScreen;
-    byte _menuItemHeight;
-    byte _menuPageScreenTopOffset;
-    byte _menuValuesLeftOffset;
-    byte _menuItemFontSize;
+    GEMAppearance* _appearanceCurrent = nullptr;
+    GEMAppearance _appearance;
+    GEMAppearance* getCurrentAppearance();
+    byte getMenuItemsPerScreen();
+    byte getMenuItemFontSize();
     FontSize _menuItemFont[2] = {{6,8},{4,6}};
     FontFamiliesU8g2 _fontFamilies = {GEM_FONT_BIG, GEM_FONT_SMALL};
     bool _cyrillicEnabled = false;
     bool _invertKeysDuringEdit = false;
-    byte _menuItemInsetOffset;
-    byte _menuItemTitleLength;
-    byte _menuItemValueLength;
+    byte getMenuItemTitleLength();
+    byte getMenuItemValueLength();
     Splash _splash;
     uint16_t _splashDelay = 1000;
     bool _enableVersion = true;
@@ -161,7 +169,6 @@ class GEM_u8g2 {
     /* DRAW OPERATIONS */
 
     GEMPage* _menuPageCurrent = nullptr;
-    void layoutMenu();
     void drawTitleBar();
     void printMenuItemString(const char* str, byte num, byte startPos = 0);
     void printMenuItemTitle(const char* str, int offset = 0);

--- a/src/GEM_u8g2.h
+++ b/src/GEM_u8g2.h
@@ -134,6 +134,7 @@ class GEM_u8g2 {
     GEM_u8g2& init();                                         // Init the menu (set necessary settings, display GEM splash screen, etc.)
     GEM_u8g2& reInit();                                       // Reinitialize the menu (call U8g2::initDisplay() and then reapply GEM specific settings)
     GEM_u8g2& setMenuPageCurrent(GEMPage& menuPageCurrent);   // Set supplied menu page as current
+    GEMPage* getCurrentMenuPage();                            // Get pointer to current menu page
 
     /* CONTEXT OPERATIONS */
 

--- a/src/config.h
+++ b/src/config.h
@@ -1,23 +1,24 @@
-// AltSerialGraphicLCD support enabled by default.
-// Can be disabled either by defining GEM_DISABLE_GLCD (via compiler flag or define) or manual edition here.
-#ifndef GEM_DISABLE_GLCD
+// AltSerialGraphicLCD support disabled by default (since GEM ver. 1.5).
+// Can be enabled either by defining GEM_ENABLE_GLCD (via compiler flag or define) or manual edition here.
+#define GEM_DISABLE_GLCD
+#if !defined(GEM_DISABLE_GLCD) || defined(GEM_ENABLE_GLCD)
 #include "config/enable-glcd.h"         // Enable AltSerialGraphicLCD version of GEM
 #endif
 
 // U8g2 support enabled by default.
 // Can be disabled either by defining GEM_DISABLE_U8G2 (via compiler flag or define) or manual edition here.
-#ifndef GEM_DISABLE_U8G2
+#if !defined(GEM_DISABLE_U8G2)
 #include "config/enable-u8g2.h"         // Enable U8g2 version of GEM
 #endif
 
 // Adafruit GFX support enabled by default.
 // Can be disabled either by defining GEM_DISABLE_ADAFRUIT_GFX (via compiler flag or define) or manual edition here.
-#ifndef GEM_DISABLE_ADAFRUIT_GFX
+#if !defined(GEM_DISABLE_ADAFRUIT_GFX)
 #include "config/enable-adafruit-gfx.h" // Enable Adafruit GFX version of GEM
 #endif
 
 // Support for editable float variables enabled by default.
 // Can be disabled either by defining GEM_DISABLE_FLOAT_EDIT (via compiler flag or define) or manual edition here.
-#ifndef GEM_DISABLE_FLOAT_EDIT
+#if !defined(GEM_DISABLE_FLOAT_EDIT)
 #include "config/support-float-edit.h"  // Support for editable float and double variables (option selects support them regardless of this setting)
 #endif


### PR DESCRIPTION
* Possible **breaking change**: AltSerialGraphicLCD version disabled by default, but can be enabled explicitly via `config.h` or build flag `GEM_ENABLE_GLCD`;
* `GEMAppearance` struct, `::setAppearance()` methods added; ability to set appearance for menu pages individually and change it at a runtime;
* `GEMPage::getMenuItem()` and `GEMItem::getMenuItemNext()` methods made public for easy menu items traversing from the sketch;
* `::getCurrentMenuPage()`, `GEMPage::getCurrentMenuItem()`, `GEMPage::getCurrentMenuItemIndex()` methods added to target currently selected menu item (can be useful for certain callback functions);
* `GEMItem::setAdjustedASCIIOrder()` method added for more suitable order of characters when editing text variables in certain use cases;
* Example 06: Todo List added;
* Readme updated accordingly.