### PR TITLE
Advanced Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1227,6 +1227,15 @@ For more details on customization see corresponding section of the [wiki](https:
   *Returns*: `GEM&`, or `GEM_u8g2&`, or `GEM_adafruit_gfx&`  
   Draw menu on screen, with menu page set earlier in `setMenuPageCurrent()`.
 
+* *GEM&* **setDrawMenuCallback(** _void_ (*drawMenuCallback)() **)**  
+  *Accepts*: `pointer to function`  
+  *Returns*: `GEM&`, or `GEM_u8g2&`, or `GEM_adafruit_gfx&`  
+  Specify callback function that will be called at the end of `drawMenu()`. Potentially can be used to draw something on top of the menu, e.g. notification icons in menu title, battery status, etc. However, note that for different versions of GEM drawMenuCallback may be called different number of times: e.g. U8g2 version of GEM calls `drawMenu()` method more often than other versions do, especially when buffer modes `_1` or `_2` of U8g2 is enabled. Alternatively, Adafruit GFX and AltSerialGraphicLCD versions of GEM make use of partial updates of the screen, hence call to `drawMenu()` is less common. Keep that in mind when specifying callback function, and consider using U8g2 version of GEM with full buffer `_F` mode.
+
+* *GEM&* **removeDrawMenuCallback()**  
+  *Returns*: `GEM&`, or `GEM_u8g2&`, or `GEM_adafruit_gfx&`  
+  Disable callback that was called at the end of `drawMenu()`.
+
 * *bool* **readyForKey()**  
   *Returns*: `bool`  
   Check that menu is waiting for the key press.

--- a/README.md
+++ b/README.md
@@ -1104,6 +1104,10 @@ For more details on customization see corresponding section of the [wiki](https:
   *Returns*: `GEM&`, or `GEM_u8g2&`, or `GEM_adafruit_gfx&`  
   Set general appearance of the menu (can be overridden in `GEMPage` on per page basis).
 
+* *GEMAppearance** **getCurrentAppearance()**  
+  *Returns*: `GEMAppearance*`  
+  Get appearance (as a pointer to [`GEMAppearance`](#gemappearance) object) applied to current menu page (or general if menu page has none of its own).
+
 * *GEM&* **setSplash(** _const uint8_t PROGMEM_ *sprite **)**  `AltSerialGraphicLCD version`  
   *Accepts*: `_const uint8_t PROGMEM_ *`  
   *Returns*: `GEM&`  

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Supports [AltSerialGraphicLCD](http://www.jasspa.com/serialGLCD.html) (since GEM
   * [GEMSelect](#gemselect)
   * [GEMCallbackData](#gemcallbackdata)
   * [GEMAppearance](#gemappearance)
-  * [AppContext](#appcontext)
+  * [GEMContext](#gemcontext)
 * [Floating-point variables](#floating-point-variables)
 * [Configuration](#configuration)
 * [Compatibility](#compatibility)
@@ -360,7 +360,7 @@ void printData() {
 }
 ```
 
-> This is the simplest action that menu item button can have. More elaborate versions make use of custom "[context](#appcontext)" that can be created when button is pressed. In that case, button action can have its own setup and loop functions (named `context.enter()` and `context.loop()`) that run similarly to how sketch operates. It allows you to initialize variables and e.g. prepare screen (if needed for the task that function performs), and then run through loop function, waiting for user input, or sensor reading, or command to terminate and exit back to the menu eventually. In the latter case additional `context.exit()` function will be called, that can be used to clean up your context and e.g. to free some memory and draw menu back to screen.
+> This is the simplest action that menu item button can have. More elaborate versions make use of custom "[context](#gemcontext)" that can be created when button is pressed. In that case, button action can have its own setup and loop functions (named `context.enter()` and `context.loop()`) that run similarly to how sketch operates. It allows you to initialize variables and e.g. prepare screen (if needed for the task that function performs), and then run through loop function, waiting for user input, or sensor reading, or command to terminate and exit back to the menu eventually. In the latter case additional `context.exit()` function will be called, that can be used to clean up your context and e.g. to free some memory and draw menu back to screen.
 
 #### Sketch
 
@@ -576,7 +576,7 @@ void printData() {
 }
 ```
 
-> This is the simplest action that menu item button can have. More elaborate versions make use of custom "[context](#appcontext)" that can be created when button is pressed. In that case, button action can have its own setup and loop functions (named `context.enter()` and `context.loop()`) that run similarly to how sketch operates. It allows you to initialize variables and e.g. prepare screen (if needed for the task that function performs), and then run through loop function, waiting for user input, or sensor reading, or command to terminate and exit back to the menu eventually. In the latter case additional `context.exit()` function will be called, that can be used to clean up your context and e.g. to free some memory and draw menu back to screen.
+> This is the simplest action that menu item button can have. More elaborate versions make use of custom "[context](#gemcontext)" that can be created when button is pressed. In that case, button action can have its own setup and loop functions (named `context.enter()` and `context.loop()`) that run similarly to how sketch operates. It allows you to initialize variables and e.g. prepare screen (if needed for the task that function performs), and then run through loop function, waiting for user input, or sensor reading, or command to terminate and exit back to the menu eventually. In the latter case additional `context.exit()` function will be called, that can be used to clean up your context and e.g. to free some memory and draw menu back to screen.
 
 #### Sketch
 
@@ -866,7 +866,7 @@ void printData() {
 }
 ```
 
-> This is the simplest action that menu item button can have. More elaborate versions make use of custom "[context](#appcontext)" that can be created when button is pressed. In that case, button action can have its own setup and loop functions (named `context.enter()` and `context.loop()`) that run similarly to how sketch operates. It allows you to initialize variables and e.g. prepare screen (if needed for the task that function performs), and then run through loop function, waiting for user input, or sensor reading, or command to terminate and exit back to the menu eventually. In the latter case additional `context.exit()` function will be called, that can be used to clean up your context and e.g. to free some memory and draw menu back to screen.
+> This is the simplest action that menu item button can have. More elaborate versions make use of custom "[context](#gemcontext)" that can be created when button is pressed. In that case, button action can have its own setup and loop functions (named `context.enter()` and `context.loop()`) that run similarly to how sketch operates. It allows you to initialize variables and e.g. prepare screen (if needed for the task that function performs), and then run through loop function, waiting for user input, or sensor reading, or command to terminate and exit back to the menu eventually. In the latter case additional `context.exit()` function will be called, that can be used to clean up your context and e.g. to free some memory and draw menu back to screen.
 
 #### Sketch
 
@@ -1177,7 +1177,7 @@ For more details on customization see corresponding section of the [wiki](https:
 
 * *GEM&* **reInit()**  
   **Returns*: `GEM&`, or `GEM_u8g2&`, or `GEM_adafruit_gfx&`  
-  Set GEM specific settings to their values, set initially in `init()` method. If you were working with AltSerialGraphicLCD, U8g2 or Adafruit GFX graphics in your own user-defined button action, it may be a good idea to call `reInit()` before drawing menu back to screen (generally in custom `context.exit()` routine). See [context](#appcontext) for more details.
+  Set GEM specific settings to their values, set initially in `init()` method. If you were working with AltSerialGraphicLCD, U8g2 or Adafruit GFX graphics in your own user-defined button action, it may be a good idea to call `reInit()` before drawing menu back to screen (generally in custom `context.exit()` routine). See [context](#gemcontext) for more details.
 
 * *GEM_adafruit_gfx&* **setTextSize(** _uint8_t_ size **)**  `Adafruit GFX version only`  
   *Accepts*: `uint8_t`  
@@ -1245,8 +1245,8 @@ For more details on customization see corresponding section of the [wiki](https:
 #### Properties
 
 * **context**  
-  *Type*: `AppContext`  
-  Currently set [context](#appcontext).
+  *Type*: `GEMContext`  
+  Currently set [context](#gemcontext).
 
 
 ----------
@@ -1272,7 +1272,7 @@ GEMPage menuPage(title[, parentMenuPage]);
 
 * **exitAction** [*optional*]  
   *Type*: `pointer to function`  
-  Pointer to a function that will be executed when `GEM_KEY_CANCEL` key is pressed while being on top level menu page (i.e. page that has no parent menu page) and not in edit mode. Action-specific [context](#appcontext) can be created, which can have its own enter (setup) and exit callbacks as well as loop function. Current menu item will be set to the first item of the menu page upon calling this function, this change will be reflected with the subsequent explicit redraw of the menu (e.g. by calling `drawMenu()` method of `GEM`, `GEM_u8g2` or `GEM_adafruit_gfx` object).
+  Pointer to a function that will be executed when `GEM_KEY_CANCEL` key is pressed while being on top level menu page (i.e. page that has no parent menu page) and not in edit mode. Action-specific [context](#gemcontext) can be created, which can have its own enter (setup) and exit callbacks as well as loop function. Current menu item will be set to the first item of the menu page upon calling this function, this change will be reflected with the subsequent explicit redraw of the menu (e.g. by calling `drawMenu()` method of `GEM`, `GEM_u8g2` or `GEM_adafruit_gfx` object).
 
 * **parentMenuPage** [*optional*]  
   *Type*: `GEMPage`  
@@ -1455,7 +1455,7 @@ GEMItem menuItemButton(title, buttonAction[, callbackVal[, readonly]]);
 
 * **buttonAction**  
   *Type*: `pointer to function`  
-  Pointer to function that will be executed when menu item is activated. Action-specific [context](#appcontext) can be created, which can have its own enter (setup) and exit callbacks as well as loop function. Optionally, callback function can expect argument of type `GEMCallbackData` to be passed to it when it is executed. In this case optional user-defined value of an argument can be specified (see below).
+  Pointer to function that will be executed when menu item is activated. Action-specific [context](#gemcontext) can be created, which can have its own enter (setup) and exit callbacks as well as loop function. Optionally, callback function can expect argument of type `GEMCallbackData` to be passed to it when it is executed. In this case optional user-defined value of an argument can be specified (see below).
 
 * **callbackVal** [*optional*]  
   *Type*: `int`, `byte`, `float`, `double`, `bool`, `const char*`, `void*`  
@@ -1862,16 +1862,16 @@ For more details about appearance customization see corresponding section of the
 ----------
 
 
-### AppContext
+### GEMContext
 
-Data structure that represents "context" of the currently executing user action, toggled by pressing menu item button. Property `context` of the `GEM` (`GEM_u8g2`, `GEM_adafruit_gfx`) object is of type `AppContext`. 
+Data structure that represents "context" of currently executing user action, toggled by pressing menu item button. Property `context` of the `GEM` (`GEM_u8g2`, `GEM_adafruit_gfx`) object is of type `GEMContext`. 
 
 Consists of pointers to user-supplied functions that represent setup and loop functions (named `context.enter()` and `context.loop()` respectively) of the context. It allows you to initialize variables and e.g. prepare screen (if needed for the task that function performs), and then run through loop function, waiting for user input, or sensor reading, or command to terminate and exit back to the menu eventually. In the latter case additional `context.exit()` function will be called, that can be used to clean up your context and e.g. to free some memory and draw menu back to screen.
 
-Object of type `AppContext` defines as follows:
+Object of type `GEMContext` (also aliased as `AppContext`) defines as follows:
 
 ```cpp
-AppContext myContext = {loop, enter, exit, allowExit};
+GEMContext myContext = {loop, enter, exit, allowExit};
 ```
 
 * **loop**  

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Supports [AltSerialGraphicLCD](http://www.jasspa.com/serialGLCD.html) (since GEM
   * [GEMAppearance](#gemappearance)
   * [GEMContext](#gemcontext)
 * [Floating-point variables](#floating-point-variables)
+* [Advanced Mode](#advanced-mode)
 * [Configuration](#configuration)
 * [Compatibility](#compatibility)
 * [Examples](#examples)
@@ -1102,7 +1103,7 @@ For more details on customization see corresponding section of the [wiki](https:
 * *GEM&* **setAppearance(** _GEMAppearance_ appearance **)**  
   *Accepts*: `GEMAppearance`  
   *Returns*: `GEM&`, or `GEM_u8g2&`, or `GEM_adafruit_gfx&`  
-  Set general appearance of the menu (can be overridden in `GEMPage` on per page basis).
+  Set general [appearance](#gemappearance) of the menu (can be overridden in `GEMPage` on per page basis).
 
 * *GEMAppearance** **getCurrentAppearance()**  
   *Returns*: `GEMAppearance*`  
@@ -1993,6 +1994,38 @@ build_flags =
 
 Note that option selects support `float` and `double` variables regardless of this setting.
 
+Advanced Mode
+-----------
+Advanced Mode provides additional means to modify, customize and extend functionality of GEM.
+
+When Advanced Mode is enabled some of the internal methods of the library is made `virtual` (marked with `GEM_VIRTUAL` macro in source code). That (alongside with `public` and `protected` access specifiers) makes it possible to override those methods in your own sketch. However keep in mind that inner workings of GEM is more prone to change than its public interface (e.g. during code refactoring), so be cautios to upgrade GEM version if your code is relying on derivative classes and overrides.
+
+Additional features of Advanced Mode may be added in the future.
+
+To enable Advanced Mode, locate file [config.h](https://github.com/Spirik/GEM/blob/master/src/config.h) that comes with the library, open it and comment out the following line:
+
+```cpp
+#define GEM_DISABLE_ADVANCED_MODE
+```
+
+to
+
+```cpp
+// #define GEM_DISABLE_ADVANCED_MODE
+```
+
+> Keep in mind that contents of the `config.h` file most likely will be reset to its default state after installing library update.
+
+Or, alternatively, define `GEM_ENABLE_ADVANCED_MODE` flag before build. E.g. in [PlatformIO](https://platformio.org/) environment via `platformio.ini`:
+
+```ini
+build_flags =
+    ; Enable Advanced Mode
+    -D GEM_ENABLE_ADVANCED_MODE
+```
+
+Note that GEM in Advanced Mode requires more memory to run, so plan accordingly.
+
 Configuration
 -----------
 It is possible to configure GEM library by excluding some features not needed in your project. That may help to save some additional program storage space. E.g., you can disable support for editable floating-point variables (see previous [section](#floating-point-variables)).
@@ -2023,7 +2056,7 @@ To _disable_ `Adafruit GFX` support comment out the following line:
 #include "config/enable-adafruit-gfx.h"
 ```
 
-More configuration options may be be added in the future.
+More configuration options may be added in the future.
 
 > Keep in mind that contents of the `config.h` file most likely will be reset to its default state after installing library update.
 

--- a/README.md
+++ b/README.md
@@ -1998,7 +1998,7 @@ Advanced Mode
 -----------
 Advanced Mode provides additional means to modify, customize and extend functionality of GEM.
 
-When Advanced Mode is enabled some of the internal methods of the library is made `virtual` (marked with `GEM_VIRTUAL` macro in source code). That (alongside with `public` and `protected` access specifiers) makes it possible to override those methods in your own sketch. However keep in mind that inner workings of GEM is more prone to change than its public interface (e.g. during code refactoring), so be cautios to upgrade GEM version if your code is relying on derivative classes and overrides.
+When Advanced Mode is enabled some of the internal methods of the library is made `virtual` (marked with `GEM_VIRTUAL` macro in source code). That (alongside with `public` and `protected` access specifiers) makes it possible to override those methods in your own sketch. However keep in mind that inner workings of GEM is more prone to change than its public interface (e.g. during code refactoring), so be cautious to upgrade GEM version if your code is relying on derivative classes and overrides.
 
 Additional features of Advanced Mode may be added in the future.
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -30,6 +30,7 @@ SelectOptionDouble	KEYWORD1
 ####################################################
 
 setAppearance	KEYWORD2
+getCurrentAppearance	KEYWORD2
 setSplash	KEYWORD2
 setSplashDelay	KEYWORD2
 hideVersion	KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -14,10 +14,11 @@ GEMPage	KEYWORD1
 GEMSelect	KEYWORD1
 GEMCallbackData	KEYWORD1
 GEMAppearance	KEYWORD1
+GEMContext	KEYWORD1
+AppContext	KEYWORD1
 Splash	KEYWORD1
 FontSize	KEYWORD1
 FontFamilies	KEYWORD1
-AppContext	KEYWORD1
 SelectOptionInt	KEYWORD1
 SelectOptionByte	KEYWORD1
 SelectOptionChar	KEYWORD1

--- a/keywords.txt
+++ b/keywords.txt
@@ -46,6 +46,8 @@ reInit	KEYWORD2
 setMenuPageCurrent	KEYWORD2
 getCurrentMenuPage	KEYWORD2
 drawMenu	KEYWORD2
+setDrawMenuCallback	KEYWORD2
+removeDrawMenuCallback	KEYWORD2
 readyForKey	KEYWORD2
 registerKeyPress	KEYWORD2
 clearContext	KEYWORD2

--- a/src/GEM.cpp
+++ b/src/GEM.cpp
@@ -259,6 +259,19 @@ GEM& GEM::drawMenu() {
   printMenuItems();
   drawMenuPointer();
   drawScrollbar();
+  if (drawMenuCallback != nullptr) {
+    drawMenuCallback();
+  }
+  return *this;
+}
+
+GEM& GEM::setDrawMenuCallback(void (*drawMenuCallback_)()) {
+  drawMenuCallback = drawMenuCallback_;
+  return *this;
+}
+
+GEM& GEM::removeDrawMenuCallback() {
+  drawMenuCallback = nullptr;
   return *this;
 }
 

--- a/src/GEM.h
+++ b/src/GEM.h
@@ -128,7 +128,7 @@ class GEM {
     bool readyForKey();                                     // Check that menu is waiting for the key press
     GEM& registerKeyPress(byte keyCode);                    // Register the key press and trigger corresponding action
                                                             // Accepts GEM_KEY_NONE, GEM_KEY_UP, GEM_KEY_RIGHT, GEM_KEY_DOWN, GEM_KEY_LEFT, GEM_KEY_CANCEL, GEM_KEY_OK values
-  private:
+  protected:
     GLCD& _glcd;
     GEMAppearance* _appearanceCurrent = nullptr;
     GEMAppearance _appearance;

--- a/src/GEM.h
+++ b/src/GEM.h
@@ -91,41 +91,43 @@ class GEM {
 
     /* APPEARANCE OPERATIONS */
 
-    GEM& setAppearance(GEMAppearance appearance);       // Set apperance of the menu (can be overridden in GEMPage on per page basis)
+    GEM& setAppearance(GEMAppearance appearance);           // Set apperance of the menu (can be overridden in GEMPage on per page basis)
 
     /* INIT OPERATIONS */
 
-    GEM& setSplash(const uint8_t *sprite);              // Set custom sprite displayed as the splash screen when GEM is being initialized. Should be called before GEM::init().
-                                                        // The following is the format of the sprite as described in AltSerialGraphicLCD library documentation.
-                                                        // The sprite commences with two bytes which are the width and height of the image in pixels.
-                                                        // The pixel data is organised as rows of 8 vertical pixels per byte where the least significant bit (LSB)
-                                                        // is the top-left pixel and the most significant bit (MSB) tends towards the bottom-left pixel.
-                                                        // A complete row of 8 vertical pixels across the image width comprises the first row, this is then followed
-                                                        // by the next row of 8 vertical pixels and so on.
-                                                        // Where the image height is not an exact multiple of 8 bits then any unused bits are typically set to zero
-                                                        // (although this does not matter).
-    GEM& setSplashDelay(uint16_t value);                // Set splash screen delay. Default value 1000ms, max value 65535ms. Setting to 0 will disable splash screen. Should be called before GEM::init().
-    GEM& hideVersion(bool flag = true);                 // Turn printing of the current GEM library version on splash screen off or back on. Should be called before GEM::init().
-    GEM& invertKeysDuringEdit(bool invert = true);      // Turn inverted order of characters during edit mode on or off
-    GEM& init();                                        // Init the menu (load necessary sprites into RAM of the SparkFun Graphic LCD Serial Backpack, display GEM splash screen, etc.)
-    GEM& reInit();                                      // Reinitialize the menu (apply GEM specific settings to AltSerialGraphicLCD library)
-    GEM& setMenuPageCurrent(GEMPage& menuPageCurrent);  // Set supplied menu page as current
-    GEMPage* getCurrentMenuPage();                      // Get pointer to current menu page
+    GEM& setSplash(const uint8_t *sprite);                  // Set custom sprite displayed as the splash screen when GEM is being initialized. Should be called before GEM::init().
+                                                            // The following is the format of the sprite as described in AltSerialGraphicLCD library documentation.
+                                                            // The sprite commences with two bytes which are the width and height of the image in pixels.
+                                                            // The pixel data is organised as rows of 8 vertical pixels per byte where the least significant bit (LSB)
+                                                            // is the top-left pixel and the most significant bit (MSB) tends towards the bottom-left pixel.
+                                                            // A complete row of 8 vertical pixels across the image width comprises the first row, this is then followed
+                                                            // by the next row of 8 vertical pixels and so on.
+                                                            // Where the image height is not an exact multiple of 8 bits then any unused bits are typically set to zero
+                                                            // (although this does not matter).
+    GEM& setSplashDelay(uint16_t value);                    // Set splash screen delay. Default value 1000ms, max value 65535ms. Setting to 0 will disable splash screen. Should be called before GEM::init().
+    GEM& hideVersion(bool flag = true);                     // Turn printing of the current GEM library version on splash screen off or back on. Should be called before GEM::init().
+    GEM& invertKeysDuringEdit(bool invert = true);          // Turn inverted order of characters during edit mode on or off
+    GEM& init();                                            // Init the menu (load necessary sprites into RAM of the SparkFun Graphic LCD Serial Backpack, display GEM splash screen, etc.)
+    GEM& reInit();                                          // Reinitialize the menu (apply GEM specific settings to AltSerialGraphicLCD library)
+    GEM& setMenuPageCurrent(GEMPage& menuPageCurrent);      // Set supplied menu page as current
+    GEMPage* getCurrentMenuPage();                          // Get pointer to current menu page
 
     /* CONTEXT OPERATIONS */
 
-    GEMContext context;                                  // Currently set context
-    GEM& clearContext();                                 // Clear context
+    GEMContext context;                                     // Currently set context
+    GEM& clearContext();                                    // Clear context
 
     /* DRAW OPERATIONS */
 
-    GEM& drawMenu();                                     // Draw menu on screen, with menu page set earlier in GEM::setMenuPageCurrent()
+    GEM& drawMenu();                                        // Draw menu on screen, with menu page set earlier in GEM::setMenuPageCurrent()
+    GEM& setDrawMenuCallback(void (*drawMenuCallback_)());  // Set callback that will be called at the end of GEM::drawMenu()
+    GEM& removeDrawMenuCallback();                          // Remove callback that was called at the end of GEM::drawMenu()
 
     /* KEY DETECTION */
 
-    bool readyForKey();                                  // Check that menu is waiting for the key press
-    GEM& registerKeyPress(byte keyCode);                 // Register the key press and trigger corresponding action
-                                                         // Accepts GEM_KEY_NONE, GEM_KEY_UP, GEM_KEY_RIGHT, GEM_KEY_DOWN, GEM_KEY_LEFT, GEM_KEY_CANCEL, GEM_KEY_OK values
+    bool readyForKey();                                     // Check that menu is waiting for the key press
+    GEM& registerKeyPress(byte keyCode);                    // Register the key press and trigger corresponding action
+                                                            // Accepts GEM_KEY_NONE, GEM_KEY_UP, GEM_KEY_RIGHT, GEM_KEY_DOWN, GEM_KEY_LEFT, GEM_KEY_CANCEL, GEM_KEY_OK values
   private:
     GLCD& _glcd;
     GEMAppearance* _appearanceCurrent = nullptr;
@@ -144,6 +146,7 @@ class GEM {
     /* DRAW OPERATIONS */
 
     GEMPage* _menuPageCurrent = nullptr;
+    void (*drawMenuCallback)() = nullptr;
     void drawTitleBar();
     void printMenuItemString(const char* str, byte num, byte startPos = 0);
     void printMenuItemTitle(const char* str, int offset = 0);

--- a/src/GEM.h
+++ b/src/GEM.h
@@ -107,8 +107,8 @@ class GEM {
     GEM& setSplashDelay(uint16_t value);                    // Set splash screen delay. Default value 1000ms, max value 65535ms. Setting to 0 will disable splash screen. Should be called before GEM::init().
     GEM& hideVersion(bool flag = true);                     // Turn printing of the current GEM library version on splash screen off or back on. Should be called before GEM::init().
     GEM& invertKeysDuringEdit(bool invert = true);          // Turn inverted order of characters during edit mode on or off
-    GEM& init();                                            // Init the menu (load necessary sprites into RAM of the SparkFun Graphic LCD Serial Backpack, display GEM splash screen, etc.)
-    GEM& reInit();                                          // Reinitialize the menu (apply GEM specific settings to AltSerialGraphicLCD library)
+    GEM_VIRTUAL GEM& init();                                // Init the menu (load necessary sprites into RAM of the SparkFun Graphic LCD Serial Backpack, display GEM splash screen, etc.)
+    GEM_VIRTUAL GEM& reInit();                              // Reinitialize the menu (apply GEM specific settings to AltSerialGraphicLCD library)
     GEM& setMenuPageCurrent(GEMPage& menuPageCurrent);      // Set supplied menu page as current
     GEMPage* getCurrentMenuPage();                          // Get pointer to current menu page
 
@@ -119,7 +119,7 @@ class GEM {
 
     /* DRAW OPERATIONS */
 
-    GEM& drawMenu();                                        // Draw menu on screen, with menu page set earlier in GEM::setMenuPageCurrent()
+    GEM_VIRTUAL GEM& drawMenu();                                        // Draw menu on screen, with menu page set earlier in GEM::setMenuPageCurrent()
     GEM& setDrawMenuCallback(void (*drawMenuCallback_)());  // Set callback that will be called at the end of GEM::drawMenu()
     GEM& removeDrawMenuCallback();                          // Remove callback that was called at the end of GEM::drawMenu()
 
@@ -137,8 +137,8 @@ class GEM {
     byte getMenuItemFontSize();
     FontSize _menuItemFont[2] = {{6,8},{4,6}};
     bool _invertKeysDuringEdit = false;
-    byte getMenuItemTitleLength();
-    byte getMenuItemValueLength();
+    GEM_VIRTUAL byte getMenuItemTitleLength();
+    GEM_VIRTUAL byte getMenuItemValueLength();
     const uint8_t *_splash;
     uint16_t _splashDelay = 1000;
     bool _enableVersion = true;
@@ -147,22 +147,22 @@ class GEM {
 
     GEMPage* _menuPageCurrent = nullptr;
     void (*drawMenuCallback)() = nullptr;
-    void drawTitleBar();
-    void printMenuItemString(const char* str, byte num, byte startPos = 0);
-    void printMenuItemTitle(const char* str, int offset = 0);
-    void printMenuItemValue(const char* str, int offset = 0, byte startPos = 0);
-    void printMenuItemFull(const char* str, int offset = 0);
-    byte getMenuItemInsetOffset(bool forSprite = false);
-    byte getCurrentItemTopOffset(bool withInsetOffset = true, bool forSprite = false);
-    void printMenuItems();
-    void drawMenuPointer();
-    void drawScrollbar();
+    GEM_VIRTUAL void drawTitleBar();
+    GEM_VIRTUAL void printMenuItemString(const char* str, byte num, byte startPos = 0);
+    GEM_VIRTUAL void printMenuItemTitle(const char* str, int offset = 0);
+    GEM_VIRTUAL void printMenuItemValue(const char* str, int offset = 0, byte startPos = 0);
+    GEM_VIRTUAL void printMenuItemFull(const char* str, int offset = 0);
+    GEM_VIRTUAL byte getMenuItemInsetOffset(bool forSprite = false);
+    GEM_VIRTUAL byte getCurrentItemTopOffset(bool withInsetOffset = true, bool forSprite = false);
+    GEM_VIRTUAL void printMenuItems();
+    GEM_VIRTUAL void drawMenuPointer();
+    GEM_VIRTUAL void drawScrollbar();
 
     /* MENU ITEMS NAVIGATION */
 
-    void nextMenuItem();
-    void prevMenuItem();
-    void menuItemSelect();
+    GEM_VIRTUAL void nextMenuItem();
+    GEM_VIRTUAL void prevMenuItem();
+    GEM_VIRTUAL void menuItemSelect();
 
     /* VALUE EDIT */
 
@@ -173,22 +173,22 @@ class GEM {
     byte _editValueVirtualCursorPosition;
     char _valueString[GEM_STR_LEN];
     int _valueSelectNum;
-    void enterEditValueMode();
-    void checkboxToggle();
-    void clearValueVisibleRange();
-    void initEditValueCursor();
-    void nextEditValueCursorPosition();
-    void prevEditValueCursorPosition();
-    void drawEditValueCursor();
-    void nextEditValueDigit();
-    void prevEditValueDigit();
-    void drawEditValueDigit(byte code);
-    void nextEditValueSelect();
-    void prevEditValueSelect();
-    void drawEditValueSelect();
-    void saveEditValue();
-    void cancelEditValue();
-    void exitEditValue();
+    GEM_VIRTUAL void enterEditValueMode();
+    GEM_VIRTUAL void checkboxToggle();
+    GEM_VIRTUAL void clearValueVisibleRange();
+    GEM_VIRTUAL void initEditValueCursor();
+    GEM_VIRTUAL void nextEditValueCursorPosition();
+    GEM_VIRTUAL void prevEditValueCursorPosition();
+    GEM_VIRTUAL void drawEditValueCursor();
+    GEM_VIRTUAL void nextEditValueDigit();
+    GEM_VIRTUAL void prevEditValueDigit();
+    GEM_VIRTUAL void drawEditValueDigit(byte code);
+    GEM_VIRTUAL void nextEditValueSelect();
+    GEM_VIRTUAL void prevEditValueSelect();
+    GEM_VIRTUAL void drawEditValueSelect();
+    GEM_VIRTUAL void saveEditValue();
+    GEM_VIRTUAL void cancelEditValue();
+    GEM_VIRTUAL void exitEditValue();
     char* trimString(char* str);
 
     /* KEY DETECTION */

--- a/src/GEM.h
+++ b/src/GEM.h
@@ -92,6 +92,7 @@ class GEM {
     /* APPEARANCE OPERATIONS */
 
     GEM& setAppearance(GEMAppearance appearance);           // Set apperance of the menu (can be overridden in GEMPage on per page basis)
+    GEMAppearance* getCurrentAppearance();                  // Get appearance (as a pointer to GEMAppearance) applied to current menu page (or general if menu page has none of its own)
 
     /* INIT OPERATIONS */
 
@@ -132,7 +133,6 @@ class GEM {
     GLCD& _glcd;
     GEMAppearance* _appearanceCurrent = nullptr;
     GEMAppearance _appearance;
-    GEMAppearance* getCurrentAppearance();
     byte getMenuItemsPerScreen();
     byte getMenuItemFontSize();
     FontSize _menuItemFont[2] = {{6,8},{4,6}};

--- a/src/GEM.h
+++ b/src/GEM.h
@@ -41,6 +41,7 @@
 
 #include <AltSerialGraphicLCD.h>
 #include "GEMAppearance.h"
+#include "GEMContext.h"
 #include "GEMPage.h"
 #include "GEMSelect.h"
 #include "constants.h"
@@ -58,19 +59,6 @@
 struct FontSize {
   byte width;   // Width of the character
   byte height;  // Height of the character
-};
-
-// Declaration of AppContext type
-struct AppContext {
-  void (*loop)();   // Pointer to loop() function of current context (similar to regular loop() function: if context is defined, executed each regular loop() iteration),
-                    // usually contains code of user-defined action that is run when menu Button is pressed
-  void (*enter)();  // Pointer to enter() function of current context (similar to regular setup() function, called manually, generally once before context's loop() function, optional),
-                    // usually contains some additional set up required by the user-defined action pointed to by context's loop()
-  void (*exit)();   // Pointer to exit() function of current context (executed when user exits currently running context, optional),
-                    // usually contains instructions to do some cleanup after context's loop() and to draw menu on screen again,
-                    // if no user-defined function specified, default action will take place that consists of call to reInit(), drawMenu() and clearContext() methods
-  bool allowExit = true;  // Setting to false will require manually exit the context's loop() from within the loop itself (all necessary key detection should be done in context's loop() accordingly),
-                          // otherwise exit is handled automatically by pressing GEM_KEY_CANCEL key (default is true)
 };
 
 // Forward declaration of necessary classes
@@ -126,7 +114,7 @@ class GEM {
 
     /* CONTEXT OPERATIONS */
 
-    AppContext context;                                  // Currently set context
+    GEMContext context;                                  // Currently set context
     GEM& clearContext();                                 // Clear context
 
     /* DRAW OPERATIONS */

--- a/src/GEMContext.h
+++ b/src/GEMContext.h
@@ -1,0 +1,55 @@
+/*
+  GEMContext (a.k.a. AppContext) - struct for storing "context" of currently executing user action.
+
+  GEM (a.k.a. Good Enough Menu) - Arduino library for creation of graphic multi-level menu with
+  editable menu items, such as variables (supports int, byte, float, double, bool, char[17] data types)
+  and option selects. User-defined callback function can be specified to invoke when menu item is saved.
+  
+  Supports buttons that can invoke user-defined actions and create action-specific
+  context, which can have its own enter (setup) and exit callbacks as well as loop function.
+
+  Supports:
+  - AltSerialGraphicLCD library by Jon Green (http://www.jasspa.com/serialGLCD.html);
+  - U8g2 library by olikraus (https://github.com/olikraus/U8g2_Arduino);
+  - Adafruit GFX library by Adafruit (https://github.com/adafruit/Adafruit-GFX-Library).
+
+  For documentation visit:
+  https://github.com/Spirik/GEM
+
+  Copyright (c) 2018-2024 Alexander 'Spirik' Spiridonov
+
+  This file is part of GEM library.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+  
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  Lesser General Public License for more details.
+  
+  You should have received a copy of the GNU Lesser General Public License
+  along with this library.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef HEADER_GEMCONTEXT
+#define HEADER_GEMCONTEXT
+
+// Declaration of GEMContext type
+struct GEMContext {
+  void (*loop)();   // Pointer to loop() function of current context (similar to regular loop() function: if context is defined, executed each regular loop() iteration),
+                    // usually contains code of user-defined action that is run when menu Button is pressed
+  void (*enter)();  // Pointer to enter() function of current context (similar to regular setup() function, called manually, generally once before context's loop() function, optional),
+                    // usually contains some additional set up required by the user-defined action pointed to by context's loop()
+  void (*exit)();   // Pointer to exit() function of current context (executed when user exits currently running context, optional),
+                    // usually contains instructions to do some cleanup after context's loop() and to draw menu on screen again,
+                    // if no user-defined function specified, default action will take place that consists of call to reInit(), drawMenu() and clearContext() methods
+  bool allowExit = true;  // Setting to false will require manually exit the context's loop() from within the loop itself (all necessary key detection should be done in context's loop() accordingly),
+                          // otherwise exit is handled automatically by pressing GEM_KEY_CANCEL key (default is true)
+};
+
+#define AppContext GEMContext
+  
+#endif

--- a/src/GEMItem.h
+++ b/src/GEMItem.h
@@ -34,6 +34,7 @@
   along with this library.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "config.h"
 #include "constants.h"
 #include "GEMPage.h"
 
@@ -274,8 +275,8 @@ class GEMItem {
     GEMItem& setCallbackVal(const char* callbackVal_);
     GEMItem& setCallbackVal(void* callbackVal_);
     GEMCallbackData getCallbackData();                  // Get GEMCallbackData struct associated with menu item
-    GEMItem& setTitle(const char* title_);              // Set title of the menu item
-    const char* getTitle();                             // Get title of the menu item
+    GEM_VIRTUAL GEMItem& setTitle(const char* title_);  // Set title of the menu item
+    GEM_VIRTUAL const char* getTitle();                 // Get title of the menu item
     GEMItem& setPrecision(byte prec);                   // Explicitly set precision for float or double variables as required by dtostrf() conversion,
                                                         // i.e. the number of digits after the decimal sign
     GEMItem& setAdjustedASCIIOrder(bool mode = true);   // Turn adjsuted order of characters when editing char[17] variables on (with space character followed by `a` and preceded by `) or off
@@ -288,8 +289,8 @@ class GEMItem {
     GEMItem& show();                                    // Explicitly show menu item
     bool getHidden();                                   // Get hidden state of the menu item
     GEMItem& remove();                                  // Remove menu item from parent menu page
-    void* getLinkedVariablePointer();                   // Get pointer to a linked variable (relevant for menu items that represent variable)
-    GEMItem* getMenuItemNext(bool total = false);       // Get next menu item (including hidden ones if total set to true)
+    GEM_VIRTUAL void* getLinkedVariablePointer();       // Get pointer to a linked variable (relevant for menu items that represent variable)
+    GEM_VIRTUAL GEMItem* getMenuItemNext(bool total = false); // Get next menu item (including hidden ones if total set to true)
   protected:
     const char* title;
     void* linkedVariable = nullptr;

--- a/src/GEMItem.h
+++ b/src/GEMItem.h
@@ -290,7 +290,7 @@ class GEMItem {
     GEMItem& remove();                                  // Remove menu item from parent menu page
     void* getLinkedVariablePointer();                   // Get pointer to a linked variable (relevant for menu items that represent variable)
     GEMItem* getMenuItemNext(bool total = false);       // Get next menu item (including hidden ones if total set to true)
-  private:
+  protected:
     const char* title;
     void* linkedVariable = nullptr;
     byte linkedType;

--- a/src/GEMPage.h
+++ b/src/GEMPage.h
@@ -84,7 +84,7 @@ class GEMPage {
     GEM_VIRTUAL void removeMenuItem(GEMItem& menuItem);                     // Remove menu item from menu page
     GEMItem* _menuItem = nullptr;                                           // First menu item of the page (the following ones are linked from within one another)
     GEMItem _menuItemBack {"", static_cast<GEMPage*>(nullptr)};             // Local instance of Back button (created when parent level menu page is specified through
-                                                                          // setParentMenuPage(); always becomes the first menu item in a list)
+                                                                            // setParentMenuPage(); always becomes the first menu item in a list)
     void (*exitAction)() = nullptr;
     GEMAppearance* _appearance = nullptr;
 };

--- a/src/GEMPage.h
+++ b/src/GEMPage.h
@@ -73,7 +73,7 @@ class GEMPage {
     GEMItem* getMenuItem(byte index, bool total = false);       // Get pointer to menu item by index (counting hidden ones if total set to true)
     GEMItem* getCurrentMenuItem();                              // Get pointer to current menu item
     byte getCurrentMenuItemIndex();                             // Get index of current menu item
-  private:
+  protected:
     const char* title;
     byte currentItemNum = 0;                                    // Currently selected (focused) menu item of the page
     byte itemsCount = 0;                                        // Items count excluding hidden ones

--- a/src/GEMPage.h
+++ b/src/GEMPage.h
@@ -65,26 +65,26 @@ class GEMPage {
     GEMPage(const char* title_);
     GEMPage(const char* title_, void (*exitAction_)());
     GEMPage(const char* title_, GEMPage& parentMenuPage_);
-    GEMPage& addMenuItem(GEMItem& menuItem, byte pos = GEM_LAST_POS, bool total = GEM_ITEMS_TOTAL);  // Add menu item to menu page (optionally at specified index out of total or only visible items)
-    GEMPage& setParentMenuPage(GEMPage& parentMenuPage);        // Specify parent level menu page (to know where to go back to when Back button is pressed)
-    GEMPage& setTitle(const char* title_);                      // Set title of the menu page
-    const char* getTitle();                                     // Get title of the menu page
-    GEMPage& setAppearance(GEMAppearance* appearance);          // Set appearance of the menu page
-    GEMItem* getMenuItem(byte index, bool total = false);       // Get pointer to menu item by index (counting hidden ones if total set to true)
-    GEMItem* getCurrentMenuItem();                              // Get pointer to current menu item
-    byte getCurrentMenuItemIndex();                             // Get index of current menu item
+    GEM_VIRTUAL GEMPage& addMenuItem(GEMItem& menuItem, byte pos = GEM_LAST_POS, bool total = GEM_ITEMS_TOTAL);  // Add menu item to menu page (optionally at specified index out of total or only visible items)
+    GEM_VIRTUAL GEMPage& setParentMenuPage(GEMPage& parentMenuPage);        // Specify parent level menu page (to know where to go back to when Back button is pressed)
+    GEM_VIRTUAL GEMPage& setTitle(const char* title_);                      // Set title of the menu page
+    GEM_VIRTUAL const char* getTitle();                                     // Get title of the menu page
+    GEMPage& setAppearance(GEMAppearance* appearance);                      // Set appearance of the menu page
+    GEM_VIRTUAL GEMItem* getMenuItem(byte index, bool total = false);       // Get pointer to menu item by index (counting hidden ones if total set to true)
+    GEM_VIRTUAL GEMItem* getCurrentMenuItem();                              // Get pointer to current menu item
+    GEM_VIRTUAL byte getCurrentMenuItemIndex();                             // Get index of current menu item
   protected:
     const char* title;
-    byte currentItemNum = 0;                                    // Currently selected (focused) menu item of the page
-    byte itemsCount = 0;                                        // Items count excluding hidden ones
-    byte itemsCountTotal = 0;                                   // Items count incuding hidden ones
-    int getMenuItemNum(GEMItem& menuItem, bool total = false);  // Find index of the supplied menu item
+    byte currentItemNum = 0;                                                // Currently selected (focused) menu item of the page
+    byte itemsCount = 0;                                                    // Items count excluding hidden ones
+    byte itemsCountTotal = 0;                                               // Items count incuding hidden ones
+    GEM_VIRTUAL int getMenuItemNum(GEMItem& menuItem, bool total = false);  // Find index of the supplied menu item
     void hideMenuItem(GEMItem& menuItem);
     void showMenuItem(GEMItem& menuItem);
-    void removeMenuItem(GEMItem& menuItem);                     // Remove menu item from menu page
-    GEMItem* _menuItem = nullptr;                               // First menu item of the page (the following ones are linked from within one another)
-    GEMItem _menuItemBack {"", static_cast<GEMPage*>(nullptr)}; // Local instance of Back button (created when parent level menu page is specified through
-                                                                // setParentMenuPage(); always becomes the first menu item in a list)
+    GEM_VIRTUAL void removeMenuItem(GEMItem& menuItem);                     // Remove menu item from menu page
+    GEMItem* _menuItem = nullptr;                                           // First menu item of the page (the following ones are linked from within one another)
+    GEMItem _menuItemBack {"", static_cast<GEMPage*>(nullptr)};             // Local instance of Back button (created when parent level menu page is specified through
+                                                                          // setParentMenuPage(); always becomes the first menu item in a list)
     void (*exitAction)() = nullptr;
     GEMAppearance* _appearance = nullptr;
 };

--- a/src/GEMSelect.h
+++ b/src/GEMSelect.h
@@ -37,6 +37,9 @@
 #ifndef HEADER_GEMSELECT
 #define HEADER_GEMSELECT
 
+#include "config.h"
+#include "constants.h"
+
 // Declaration of SelectOptionInt type
 struct SelectOptionInt {
   const char* name;    // Text label of the option as displayed in select
@@ -88,10 +91,10 @@ class GEMSelect {
     void* _options;
     byte getType();
     byte getLength();
-    int getSelectedOptionNum(void* variable);
-    const char* getSelectedOptionName(void* variable);
-    const char* getOptionNameByIndex(int index);
-    void setValue(void* variable, int index);  // Assign value of the selected option to supplied variable
+    GEM_VIRTUAL int getSelectedOptionNum(void* variable);
+    GEM_VIRTUAL const char* getSelectedOptionName(void* variable);
+    GEM_VIRTUAL const char* getOptionNameByIndex(int index);
+    GEM_VIRTUAL void setValue(void* variable, int index);  // Assign value of the selected option to supplied variable
 };
   
 #endif

--- a/src/GEMSelect.h
+++ b/src/GEMSelect.h
@@ -82,7 +82,7 @@ class GEMSelect {
     GEMSelect(byte length_, SelectOptionChar* options_);
     GEMSelect(byte length_, SelectOptionFloat* options_);
     GEMSelect(byte length_, SelectOptionDouble* options_);
-  private:
+  protected:
     byte _type;
     byte _length;
     void* _options;

--- a/src/GEM_adafruit_gfx.cpp
+++ b/src/GEM_adafruit_gfx.cpp
@@ -382,6 +382,19 @@ GEM_adafruit_gfx& GEM_adafruit_gfx::drawMenu() {
   printMenuItems();
   drawMenuPointer();
   drawScrollbar();
+  if (drawMenuCallback != nullptr) {
+    drawMenuCallback();
+  }
+  return *this;
+}
+
+GEM_adafruit_gfx& GEM_adafruit_gfx::setDrawMenuCallback(void (*drawMenuCallback_)()) {
+  drawMenuCallback = drawMenuCallback_;
+  return *this;
+}
+
+GEM_adafruit_gfx& GEM_adafruit_gfx::removeDrawMenuCallback() {
+  drawMenuCallback = nullptr;
   return *this;
 }
 

--- a/src/GEM_adafruit_gfx.h
+++ b/src/GEM_adafruit_gfx.h
@@ -147,7 +147,7 @@ class GEM_adafruit_gfx {
     bool readyForKey();                                                 // Check that menu is waiting for the key press
     GEM_adafruit_gfx& registerKeyPress(byte keyCode);                   // Register the key press and trigger corresponding action
                                                                         // Accepts GEM_KEY_NONE, GEM_KEY_UP, GEM_KEY_RIGHT, GEM_KEY_DOWN, GEM_KEY_LEFT, GEM_KEY_CANCEL, GEM_KEY_OK values
-  private:
+  protected:
     Adafruit_GFX& _agfx;
     GEMAppearance* _appearanceCurrent = nullptr;
     GEMAppearance _appearance;

--- a/src/GEM_adafruit_gfx.h
+++ b/src/GEM_adafruit_gfx.h
@@ -112,6 +112,7 @@ class GEM_adafruit_gfx {
     /* APPEARANCE OPERATIONS */
 
     GEM_adafruit_gfx& setAppearance(GEMAppearance appearance);          // Set appearance of the menu (can be overridden in GEMPage on per page basis)
+    GEMAppearance* getCurrentAppearance();                              // Get appearance (as a pointer to GEMAppearance) applied to current menu page (or general if menu page has none of its own)
 
     /* INIT OPERATIONS */
 
@@ -151,7 +152,6 @@ class GEM_adafruit_gfx {
     Adafruit_GFX& _agfx;
     GEMAppearance* _appearanceCurrent = nullptr;
     GEMAppearance _appearance;
-    GEMAppearance* getCurrentAppearance();
     byte getMenuItemsPerScreen();
     byte getMenuItemFontSize();
     FontSizeAGFX _menuItemFont[2] = {{6,8,8},{4,6,6}};

--- a/src/GEM_adafruit_gfx.h
+++ b/src/GEM_adafruit_gfx.h
@@ -126,8 +126,8 @@ class GEM_adafruit_gfx {
     GEM_adafruit_gfx& setForegroundColor(uint16_t color);               // Set foreground color of the menu (default is 0xFF)
     GEM_adafruit_gfx& setBackgroundColor(uint16_t color);               // Set background color of the menu (default is 0x00)
     GEM_adafruit_gfx& invertKeysDuringEdit(bool invert = true);         // Turn inverted order of characters during edit mode on or off
-    GEM_adafruit_gfx& init();                                           // Init the menu (load necessary sprites into RAM of the SparkFun Graphic LCD Serial Backpack, display GEM splash screen, etc.)
-    GEM_adafruit_gfx& reInit();                                         // Reinitialize the menu (apply GEM specific settings to AltSerialGraphicLCD library)
+    GEM_VIRTUAL GEM_adafruit_gfx& init();                               // Init the menu (load necessary sprites into RAM of the SparkFun Graphic LCD Serial Backpack, display GEM splash screen, etc.)
+    GEM_VIRTUAL GEM_adafruit_gfx& reInit();                             // Reinitialize the menu (apply GEM specific settings to AltSerialGraphicLCD library)
     GEM_adafruit_gfx& setMenuPageCurrent(GEMPage& menuPageCurrent);     // Set supplied menu page as current
     GEMPage* getCurrentMenuPage();                                      // Get pointer to current menu page
 
@@ -138,7 +138,7 @@ class GEM_adafruit_gfx {
 
     /* DRAW OPERATIONS */
 
-    GEM_adafruit_gfx& drawMenu();                                       // Draw menu on screen, with menu page set earlier in GEM_adafruit_gfx::setMenuPageCurrent()
+    GEM_VIRTUAL GEM_adafruit_gfx& drawMenu();                                       // Draw menu on screen, with menu page set earlier in GEM_adafruit_gfx::setMenuPageCurrent()
     GEM_adafruit_gfx& setDrawMenuCallback(void (*drawMenuCallback_)()); // Set callback that will be called at the end of GEM_adafruit_gfx::drawMenu()
     GEM_adafruit_gfx& removeDrawMenuCallback();                         // Remove callback that was called at the end of GEM_adafruit_gfx::drawMenu()
 
@@ -158,8 +158,8 @@ class GEM_adafruit_gfx {
     FontFamiliesAGFX _fontFamilies = {GEM_FONT_BIG, GEM_FONT_SMALL};
     byte _textSize = 1;
     bool _invertKeysDuringEdit = false;
-    byte getMenuItemTitleLength();
-    byte getMenuItemValueLength();
+    GEM_VIRTUAL byte getMenuItemTitleLength();
+    GEM_VIRTUAL byte getMenuItemValueLength();
     Splash _splash;
     uint16_t _splashDelay = 1000;
     bool _enableVersion = true;
@@ -170,24 +170,24 @@ class GEM_adafruit_gfx {
 
     GEMPage* _menuPageCurrent = nullptr;
     void (*drawMenuCallback)() = nullptr;
-    void drawTitleBar();
-    void drawSprite(int16_t x, int16_t y, const Splash sprite[], uint16_t color);
-    void printMenuItemString(const char* str, byte num, byte startPos = 0);
-    void printMenuItemTitle(const char* str, int offset = 0);
-    void printMenuItemValue(const char* str, int offset = 0, byte startPos = 0);
-    void printMenuItemFull(const char* str, int offset = 0);
-    byte getMenuItemInsetOffset(bool forSprite = false);
-    byte getCurrentItemTopOffset(bool withInsetOffset = true, bool forSprite = false);
-    void printMenuItem(GEMItem* menuItemTmp, byte yText, byte yDraw, uint16_t color);
-    void printMenuItems();
-    void drawMenuPointer(bool clear = false);
-    void drawScrollbar();
+    GEM_VIRTUAL void drawTitleBar();
+    GEM_VIRTUAL void drawSprite(int16_t x, int16_t y, const Splash sprite[], uint16_t color);
+    GEM_VIRTUAL void printMenuItemString(const char* str, byte num, byte startPos = 0);
+    GEM_VIRTUAL void printMenuItemTitle(const char* str, int offset = 0);
+    GEM_VIRTUAL void printMenuItemValue(const char* str, int offset = 0, byte startPos = 0);
+    GEM_VIRTUAL void printMenuItemFull(const char* str, int offset = 0);
+    GEM_VIRTUAL byte getMenuItemInsetOffset(bool forSprite = false);
+    GEM_VIRTUAL byte getCurrentItemTopOffset(bool withInsetOffset = true, bool forSprite = false);
+    GEM_VIRTUAL void printMenuItem(GEMItem* menuItemTmp, byte yText, byte yDraw, uint16_t color);
+    GEM_VIRTUAL void printMenuItems();
+    GEM_VIRTUAL void drawMenuPointer(bool clear = false);
+    GEM_VIRTUAL void drawScrollbar();
 
     /* MENU ITEMS NAVIGATION */
 
-    void nextMenuItem();
-    void prevMenuItem();
-    void menuItemSelect();
+    GEM_VIRTUAL void nextMenuItem();
+    GEM_VIRTUAL void prevMenuItem();
+    GEM_VIRTUAL void menuItemSelect();
 
     /* VALUE EDIT */
 
@@ -198,22 +198,22 @@ class GEM_adafruit_gfx {
     byte _editValueVirtualCursorPosition;
     char _valueString[GEM_STR_LEN];
     int _valueSelectNum;
-    void enterEditValueMode();
-    void checkboxToggle();
-    void clearValueVisibleRange();
-    void initEditValueCursor();
-    void nextEditValueCursorPosition();
-    void prevEditValueCursorPosition();
-    void drawEditValueCursor(bool clear = false);
-    void nextEditValueDigit();
-    void prevEditValueDigit();
-    void drawEditValueDigit(byte code, bool clear = false);
-    void nextEditValueSelect();
-    void prevEditValueSelect();
-    void drawEditValueSelect();
-    void saveEditValue();
-    void cancelEditValue();
-    void exitEditValue(bool redrawMenu = true);
+    GEM_VIRTUAL void enterEditValueMode();
+    GEM_VIRTUAL void checkboxToggle();
+    GEM_VIRTUAL void clearValueVisibleRange();
+    GEM_VIRTUAL void initEditValueCursor();
+    GEM_VIRTUAL void nextEditValueCursorPosition();
+    GEM_VIRTUAL void prevEditValueCursorPosition();
+    GEM_VIRTUAL void drawEditValueCursor(bool clear = false);
+    GEM_VIRTUAL void nextEditValueDigit();
+    GEM_VIRTUAL void prevEditValueDigit();
+    GEM_VIRTUAL void drawEditValueDigit(byte code, bool clear = false);
+    GEM_VIRTUAL void nextEditValueSelect();
+    GEM_VIRTUAL void prevEditValueSelect();
+    GEM_VIRTUAL void drawEditValueSelect();
+    GEM_VIRTUAL void saveEditValue();
+    GEM_VIRTUAL void cancelEditValue();
+    GEM_VIRTUAL void exitEditValue(bool redrawMenu = true);
     char* trimString(char* str);
 
     /* KEY DETECTION */

--- a/src/GEM_adafruit_gfx.h
+++ b/src/GEM_adafruit_gfx.h
@@ -111,40 +111,42 @@ class GEM_adafruit_gfx {
 
     /* APPEARANCE OPERATIONS */
 
-    GEM_adafruit_gfx& setAppearance(GEMAppearance appearance);        // Set appearance of the menu (can be overridden in GEMPage on per page basis)
+    GEM_adafruit_gfx& setAppearance(GEMAppearance appearance);          // Set appearance of the menu (can be overridden in GEMPage on per page basis)
 
     /* INIT OPERATIONS */
 
     GEM_adafruit_gfx& setSplash(byte width, byte height, const uint8_t *image); // Set custom bitmap image displayed as the splash screen when GEM is being initialized. Should be called before GEM_adafruit_gfx::init().
                                                                                 // The following is the format of the bitmap as described in Adafruit GFX library documentation.
                                                                                 // A contiguous block of bits, where each '1' bit sets the corresponding pixel to 'color,' while each '0' bit is skipped.
-    GEM_adafruit_gfx& setSplashDelay(uint16_t value);                 // Set splash screen delay. Default value 1000ms, max value 65535ms. Setting to 0 will disable splash screen. Should be called before GEM::init().
-    GEM_adafruit_gfx& hideVersion(bool flag = true);                  // Turn printing of the current GEM library version on splash screen off or back on. Should be called before GEM::init().
-    GEM_adafruit_gfx& setTextSize(uint8_t size);                      // Set text 'magnification' size (as per Adafruit GFX docs); sprites will be scaled maximum up to two times regardless of the supplied value (default is 1)
+    GEM_adafruit_gfx& setSplashDelay(uint16_t value);                   // Set splash screen delay. Default value 1000ms, max value 65535ms. Setting to 0 will disable splash screen. Should be called before GEM_adafruit_gfx::init().
+    GEM_adafruit_gfx& hideVersion(bool flag = true);                    // Turn printing of the current GEM library version on splash screen off or back on. Should be called before GEM_adafruit_gfx::init().
+    GEM_adafruit_gfx& setTextSize(uint8_t size);                        // Set text 'magnification' size (as per Adafruit GFX docs); sprites will be scaled maximum up to two times regardless of the supplied value (default is 1)
     GEM_adafruit_gfx& setFontBig(const GFXfont* font = GEM_FONT_BIG, uint8_t width = 6, uint8_t height = 8, uint8_t baselineOffset = 8);      // Set big font
     GEM_adafruit_gfx& setFontSmall(const GFXfont* font = GEM_FONT_SMALL, uint8_t width = 4, uint8_t height = 6, uint8_t baselineOffset = 6);  // Set small font
-    GEM_adafruit_gfx& setForegroundColor(uint16_t color);             // Set foreground color of the menu (default is 0xFF)
-    GEM_adafruit_gfx& setBackgroundColor(uint16_t color);             // Set background color of the menu (default is 0x00)
-    GEM_adafruit_gfx& invertKeysDuringEdit(bool invert = true);       // Turn inverted order of characters during edit mode on or off
-    GEM_adafruit_gfx& init();                                         // Init the menu (load necessary sprites into RAM of the SparkFun Graphic LCD Serial Backpack, display GEM splash screen, etc.)
-    GEM_adafruit_gfx& reInit();                                       // Reinitialize the menu (apply GEM specific settings to AltSerialGraphicLCD library)
-    GEM_adafruit_gfx& setMenuPageCurrent(GEMPage& menuPageCurrent);   // Set supplied menu page as current
-    GEMPage* getCurrentMenuPage();                                    // Get pointer to current menu page
+    GEM_adafruit_gfx& setForegroundColor(uint16_t color);               // Set foreground color of the menu (default is 0xFF)
+    GEM_adafruit_gfx& setBackgroundColor(uint16_t color);               // Set background color of the menu (default is 0x00)
+    GEM_adafruit_gfx& invertKeysDuringEdit(bool invert = true);         // Turn inverted order of characters during edit mode on or off
+    GEM_adafruit_gfx& init();                                           // Init the menu (load necessary sprites into RAM of the SparkFun Graphic LCD Serial Backpack, display GEM splash screen, etc.)
+    GEM_adafruit_gfx& reInit();                                         // Reinitialize the menu (apply GEM specific settings to AltSerialGraphicLCD library)
+    GEM_adafruit_gfx& setMenuPageCurrent(GEMPage& menuPageCurrent);     // Set supplied menu page as current
+    GEMPage* getCurrentMenuPage();                                      // Get pointer to current menu page
 
     /* CONTEXT OPERATIONS */
 
-    GEMContext context;                                               // Currently set context
-    GEM_adafruit_gfx& clearContext();                                 // Clear context
+    GEMContext context;                                                 // Currently set context
+    GEM_adafruit_gfx& clearContext();                                   // Clear context
 
     /* DRAW OPERATIONS */
 
-    GEM_adafruit_gfx& drawMenu();                                     // Draw menu on screen, with menu page set earlier in GEM::setMenuPageCurrent()
+    GEM_adafruit_gfx& drawMenu();                                       // Draw menu on screen, with menu page set earlier in GEM_adafruit_gfx::setMenuPageCurrent()
+    GEM_adafruit_gfx& setDrawMenuCallback(void (*drawMenuCallback_)()); // Set callback that will be called at the end of GEM_adafruit_gfx::drawMenu()
+    GEM_adafruit_gfx& removeDrawMenuCallback();                         // Remove callback that was called at the end of GEM_adafruit_gfx::drawMenu()
 
     /* KEY DETECTION */
 
-    bool readyForKey();                                               // Check that menu is waiting for the key press
-    GEM_adafruit_gfx& registerKeyPress(byte keyCode);                 // Register the key press and trigger corresponding action
-                                                                      // Accepts GEM_KEY_NONE, GEM_KEY_UP, GEM_KEY_RIGHT, GEM_KEY_DOWN, GEM_KEY_LEFT, GEM_KEY_CANCEL, GEM_KEY_OK values
+    bool readyForKey();                                                 // Check that menu is waiting for the key press
+    GEM_adafruit_gfx& registerKeyPress(byte keyCode);                   // Register the key press and trigger corresponding action
+                                                                        // Accepts GEM_KEY_NONE, GEM_KEY_UP, GEM_KEY_RIGHT, GEM_KEY_DOWN, GEM_KEY_LEFT, GEM_KEY_CANCEL, GEM_KEY_OK values
   private:
     Adafruit_GFX& _agfx;
     GEMAppearance* _appearanceCurrent = nullptr;
@@ -167,6 +169,7 @@ class GEM_adafruit_gfx {
     /* DRAW OPERATIONS */
 
     GEMPage* _menuPageCurrent = nullptr;
+    void (*drawMenuCallback)() = nullptr;
     void drawTitleBar();
     void drawSprite(int16_t x, int16_t y, const Splash sprite[], uint16_t color);
     void printMenuItemString(const char* str, byte num, byte startPos = 0);

--- a/src/GEM_adafruit_gfx.h
+++ b/src/GEM_adafruit_gfx.h
@@ -43,6 +43,7 @@
 #include "fonts/TomThumbMono.h"
 #include "fonts/Fixed6x12.h"
 #include "GEMAppearance.h"
+#include "GEMContext.h"
 #include "GEMPage.h"
 #include "GEMSelect.h"
 #include "constants.h"
@@ -78,19 +79,6 @@ struct FontSizeAGFX {
 struct FontFamiliesAGFX {
   const GFXfont *big;    // Big font family (i.e., 6x12)
   const GFXfont *small;  // Small font family (i.e., 4x6)
-};
-
-// Declaration of AppContext type
-struct AppContext {
-  void (*loop)();   // Pointer to loop() function of current context (similar to regular loop() function: if context is defined, executed each regular loop() iteration),
-                    // usually contains code of user-defined action that is run when menu Button is pressed
-  void (*enter)();  // Pointer to enter() function of current context (similar to regular setup() function, called manually, generally once before context's loop() function, optional),
-                    // usually contains some additional set up required by the user-defined action pointed to by context's loop()
-  void (*exit)();   // Pointer to exit() function of current context (executed when user exits currently running context, optional),
-                    // usually contains instructions to do some cleanup after context's loop() and to draw menu on screen again,
-                    // if no user-defined function specified, default action will take place that consists of call to reInit(), drawMenu() and clearContext() methods
-  bool allowExit = true;  // Setting to false will require manually exit the context's loop() from within the loop itself (all necessary key detection should be done in context's loop() accordingly),
-                          // otherwise exit is handled automatically by pressing GEM_KEY_CANCEL key (default is true)
 };
 
 // Forward declaration of necessary classes
@@ -145,7 +133,7 @@ class GEM_adafruit_gfx {
 
     /* CONTEXT OPERATIONS */
 
-    AppContext context;                                               // Currently set context
+    GEMContext context;                                               // Currently set context
     GEM_adafruit_gfx& clearContext();                                 // Clear context
 
     /* DRAW OPERATIONS */

--- a/src/GEM_u8g2.cpp
+++ b/src/GEM_u8g2.cpp
@@ -330,7 +330,20 @@ GEM_u8g2& GEM_u8g2::drawMenu() {
     printMenuItems();
     drawMenuPointer();
     drawScrollbar();
+    if (drawMenuCallback != nullptr) {
+      drawMenuCallback();
+    }
   } while (_u8g2.nextPage());
+  return *this;
+}
+
+GEM_u8g2& GEM_u8g2::setDrawMenuCallback(void (*drawMenuCallback_)()) {
+  drawMenuCallback = drawMenuCallback_;
+  return *this;
+}
+
+GEM_u8g2& GEM_u8g2::removeDrawMenuCallback() {
+  drawMenuCallback = nullptr;
   return *this;
 }
 

--- a/src/GEM_u8g2.h
+++ b/src/GEM_u8g2.h
@@ -145,7 +145,7 @@ class GEM_u8g2 {
     bool readyForKey();                                         // Check that menu is waiting for the key press
     GEM_u8g2& registerKeyPress(byte keyCode);                   // Register the key press and trigger corresponding action
                                                                 // Accepts GEM_KEY_NONE, GEM_KEY_UP, GEM_KEY_RIGHT, GEM_KEY_DOWN, GEM_KEY_LEFT, GEM_KEY_CANCEL, GEM_KEY_OK values
-  private:
+  protected:
     U8G2& _u8g2;
     GEMAppearance* _appearanceCurrent = nullptr;
     GEMAppearance _appearance;

--- a/src/GEM_u8g2.h
+++ b/src/GEM_u8g2.h
@@ -111,6 +111,7 @@ class GEM_u8g2 {
     /* APPEARANCE OPERATIONS */
 
     GEM_u8g2& setAppearance(GEMAppearance appearance);          // Set appearance of the menu (can be overridden in GEMPage on per page basis)
+    GEMAppearance* getCurrentAppearance();                      // Get appearance (as a pointer to GEMAppearance) applied to current menu page (or general if menu page has none of its own)
     
     /* INIT OPERATIONS */
 
@@ -149,7 +150,6 @@ class GEM_u8g2 {
     U8G2& _u8g2;
     GEMAppearance* _appearanceCurrent = nullptr;
     GEMAppearance _appearance;
-    GEMAppearance* getCurrentAppearance();
     byte getMenuItemsPerScreen();
     byte getMenuItemFontSize();
     FontSize _menuItemFont[2] = {{6,8},{4,6}};

--- a/src/GEM_u8g2.h
+++ b/src/GEM_u8g2.h
@@ -110,39 +110,41 @@ class GEM_u8g2 {
 
     /* APPEARANCE OPERATIONS */
 
-    GEM_u8g2& setAppearance(GEMAppearance appearance);        // Set appearance of the menu (can be overridden in GEMPage on per page basis)
+    GEM_u8g2& setAppearance(GEMAppearance appearance);          // Set appearance of the menu (can be overridden in GEMPage on per page basis)
     
     /* INIT OPERATIONS */
 
     GEM_u8g2& setSplash(byte width, byte height, const unsigned char *image); // Set custom XBM image displayed as the splash screen when GEM is being initialized. Should be called before GEM_u8g2::init().
-    GEM_u8g2& setSplashDelay(uint16_t value);                 // Set splash screen delay. Default value 1000ms, max value 65535ms. Setting to 0 will disable splash screen. Should be called before GEM_u8g2::init().
-    GEM_u8g2& hideVersion(bool flag = true);                  // Turn printing of the current GEM library version on splash screen off or back on. Should be called before GEM_u8g2::init().
-    GEM_u8g2& enableUTF8(bool flag = true);                   // Enable UTF8 fonts support. Generally should be called before GEM_u8g2::init(). To disable UTF8 fonts support pass false: enableUTF8(false).
-    GEM_u8g2& enableCyrillic(bool flag = true);               // Enable default Cyrillic set of fonts with GEM. Generally should be called before GEM_u8g2::init(). To revert to non-Cyrillic fonts pass false: enableCyrillic(false).
+    GEM_u8g2& setSplashDelay(uint16_t value);                   // Set splash screen delay. Default value 1000ms, max value 65535ms. Setting to 0 will disable splash screen. Should be called before GEM_u8g2::init().
+    GEM_u8g2& hideVersion(bool flag = true);                    // Turn printing of the current GEM library version on splash screen off or back on. Should be called before GEM_u8g2::init().
+    GEM_u8g2& enableUTF8(bool flag = true);                     // Enable UTF8 fonts support. Generally should be called before GEM_u8g2::init(). To disable UTF8 fonts support pass false: enableUTF8(false).
+    GEM_u8g2& enableCyrillic(bool flag = true);                 // Enable default Cyrillic set of fonts with GEM. Generally should be called before GEM_u8g2::init(). To revert to non-Cyrillic fonts pass false: enableCyrillic(false).
     GEM_u8g2& setFontBig(const uint8_t* font, uint8_t width = 6, uint8_t height = 8);   // Set big font
-    GEM_u8g2& setFontBig();                                   // Revert big font to default value (with respect to _UTF8Enabled flag)
+    GEM_u8g2& setFontBig();                                     // Revert big font to default value (with respect to _UTF8Enabled flag)
     GEM_u8g2& setFontSmall(const uint8_t* font, uint8_t width = 4, uint8_t height = 6); // Set small font
-    GEM_u8g2& setFontSmall();                                 // Revert small font to default value (with respect to _UTF8Enabled flag)
-    GEM_u8g2& invertKeysDuringEdit(bool invert = true);       // Turn inverted order of characters during edit mode on or off
-    GEM_u8g2& init();                                         // Init the menu (set necessary settings, display GEM splash screen, etc.)
-    GEM_u8g2& reInit();                                       // Reinitialize the menu (call U8g2::initDisplay() and then reapply GEM specific settings)
-    GEM_u8g2& setMenuPageCurrent(GEMPage& menuPageCurrent);   // Set supplied menu page as current
-    GEMPage* getCurrentMenuPage();                            // Get pointer to current menu page
+    GEM_u8g2& setFontSmall();                                   // Revert small font to default value (with respect to _UTF8Enabled flag)
+    GEM_u8g2& invertKeysDuringEdit(bool invert = true);         // Turn inverted order of characters during edit mode on or off
+    GEM_u8g2& init();                                           // Init the menu (set necessary settings, display GEM splash screen, etc.)
+    GEM_u8g2& reInit();                                         // Reinitialize the menu (call U8g2::initDisplay() and then reapply GEM specific settings)
+    GEM_u8g2& setMenuPageCurrent(GEMPage& menuPageCurrent);     // Set supplied menu page as current
+    GEMPage* getCurrentMenuPage();                              // Get pointer to current menu page
 
     /* CONTEXT OPERATIONS */
 
-    GEMContext context;                                       // Currently set context
-    GEM_u8g2& clearContext();                                 // Clear context
+    GEMContext context;                                         // Currently set context
+    GEM_u8g2& clearContext();                                   // Clear context
 
     /* DRAW OPERATIONS */
 
-    GEM_u8g2& drawMenu();                                     // Draw menu on screen, with menu page set earlier in GEM_u8g2::setMenuPageCurrent()
+    GEM_u8g2& drawMenu();                                       // Draw menu on screen, with menu page set earlier in GEM_u8g2::setMenuPageCurrent()
+    GEM_u8g2& setDrawMenuCallback(void (*drawMenuCallback_)()); // Set callback that will be called at the end of GEM_u8g2::drawMenu()
+    GEM_u8g2& removeDrawMenuCallback();                         // Remove callback that was called at the end of GEM_u8g2::drawMenu()
 
     /* KEY DETECTION */
 
-    bool readyForKey();                                       // Check that menu is waiting for the key press
-    GEM_u8g2& registerKeyPress(byte keyCode);                 // Register the key press and trigger corresponding action
-                                                              // Accepts GEM_KEY_NONE, GEM_KEY_UP, GEM_KEY_RIGHT, GEM_KEY_DOWN, GEM_KEY_LEFT, GEM_KEY_CANCEL, GEM_KEY_OK values
+    bool readyForKey();                                         // Check that menu is waiting for the key press
+    GEM_u8g2& registerKeyPress(byte keyCode);                   // Register the key press and trigger corresponding action
+                                                                // Accepts GEM_KEY_NONE, GEM_KEY_UP, GEM_KEY_RIGHT, GEM_KEY_DOWN, GEM_KEY_LEFT, GEM_KEY_CANCEL, GEM_KEY_OK values
   private:
     U8G2& _u8g2;
     GEMAppearance* _appearanceCurrent = nullptr;
@@ -163,6 +165,7 @@ class GEM_u8g2 {
     /* DRAW OPERATIONS */
 
     GEMPage* _menuPageCurrent = nullptr;
+    void (*drawMenuCallback)() = nullptr;
     void drawTitleBar();
     void printMenuItemString(const char* str, byte num, byte startPos = 0);
     void printMenuItemTitle(const char* str, int offset = 0);

--- a/src/GEM_u8g2.h
+++ b/src/GEM_u8g2.h
@@ -124,8 +124,8 @@ class GEM_u8g2 {
     GEM_u8g2& setFontSmall(const uint8_t* font, uint8_t width = 4, uint8_t height = 6); // Set small font
     GEM_u8g2& setFontSmall();                                   // Revert small font to default value (with respect to _UTF8Enabled flag)
     GEM_u8g2& invertKeysDuringEdit(bool invert = true);         // Turn inverted order of characters during edit mode on or off
-    GEM_u8g2& init();                                           // Init the menu (set necessary settings, display GEM splash screen, etc.)
-    GEM_u8g2& reInit();                                         // Reinitialize the menu (call U8g2::initDisplay() and then reapply GEM specific settings)
+    GEM_VIRTUAL GEM_u8g2& init();                               // Init the menu (set necessary settings, display GEM splash screen, etc.)
+    GEM_VIRTUAL GEM_u8g2& reInit();                             // Reinitialize the menu (call U8g2::initDisplay() and then reapply GEM specific settings)
     GEM_u8g2& setMenuPageCurrent(GEMPage& menuPageCurrent);     // Set supplied menu page as current
     GEMPage* getCurrentMenuPage();                              // Get pointer to current menu page
 
@@ -136,7 +136,7 @@ class GEM_u8g2 {
 
     /* DRAW OPERATIONS */
 
-    GEM_u8g2& drawMenu();                                       // Draw menu on screen, with menu page set earlier in GEM_u8g2::setMenuPageCurrent()
+    GEM_VIRTUAL GEM_u8g2& drawMenu();                           // Draw menu on screen, with menu page set earlier in GEM_u8g2::setMenuPageCurrent()
     GEM_u8g2& setDrawMenuCallback(void (*drawMenuCallback_)()); // Set callback that will be called at the end of GEM_u8g2::drawMenu()
     GEM_u8g2& removeDrawMenuCallback();                         // Remove callback that was called at the end of GEM_u8g2::drawMenu()
 
@@ -156,8 +156,8 @@ class GEM_u8g2 {
     FontFamiliesU8g2 _fontFamilies = {GEM_FONT_BIG, GEM_FONT_SMALL};
     bool _UTF8Enabled = false;
     bool _invertKeysDuringEdit = false;
-    byte getMenuItemTitleLength();
-    byte getMenuItemValueLength();
+    GEM_VIRTUAL byte getMenuItemTitleLength();
+    GEM_VIRTUAL byte getMenuItemValueLength();
     Splash _splash;
     uint16_t _splashDelay = 1000;
     bool _enableVersion = true;
@@ -166,22 +166,22 @@ class GEM_u8g2 {
 
     GEMPage* _menuPageCurrent = nullptr;
     void (*drawMenuCallback)() = nullptr;
-    void drawTitleBar();
-    void printMenuItemString(const char* str, byte num, byte startPos = 0);
-    void printMenuItemTitle(const char* str, int offset = 0);
-    void printMenuItemValue(const char* str, int offset = 0, byte startPos = 0);
-    void printMenuItemFull(const char* str, int offset = 0);
-    byte getMenuItemInsetOffset(bool forSprite = false);
-    byte getCurrentItemTopOffset(bool withInsetOffset = true, bool forSprite = false);
-    void printMenuItems();
-    void drawMenuPointer();
-    void drawScrollbar();
+    GEM_VIRTUAL void drawTitleBar();
+    GEM_VIRTUAL void printMenuItemString(const char* str, byte num, byte startPos = 0);
+    GEM_VIRTUAL void printMenuItemTitle(const char* str, int offset = 0);
+    GEM_VIRTUAL void printMenuItemValue(const char* str, int offset = 0, byte startPos = 0);
+    GEM_VIRTUAL void printMenuItemFull(const char* str, int offset = 0);
+    GEM_VIRTUAL byte getMenuItemInsetOffset(bool forSprite = false);
+    GEM_VIRTUAL byte getCurrentItemTopOffset(bool withInsetOffset = true, bool forSprite = false);
+    GEM_VIRTUAL void printMenuItems();
+    GEM_VIRTUAL void drawMenuPointer();
+    GEM_VIRTUAL void drawScrollbar();
 
     /* MENU ITEMS NAVIGATION */
 
-    void nextMenuItem();
-    void prevMenuItem();
-    void menuItemSelect();
+    GEM_VIRTUAL void nextMenuItem();
+    GEM_VIRTUAL void prevMenuItem();
+    GEM_VIRTUAL void menuItemSelect();
 
     /* VALUE EDIT */
 
@@ -192,20 +192,20 @@ class GEM_u8g2 {
     byte _editValueVirtualCursorPosition;
     char _valueString[GEM_STR_LEN];
     int _valueSelectNum;
-    void enterEditValueMode();
-    void checkboxToggle();
-    void initEditValueCursor();
-    void nextEditValueCursorPosition();
-    void prevEditValueCursorPosition();
-    void drawEditValueCursor();
-    void nextEditValueDigit();
-    void prevEditValueDigit();
-    void drawEditValueDigit(byte code);
-    void nextEditValueSelect();
-    void prevEditValueSelect();
-    void saveEditValue();
-    void cancelEditValue();
-    void exitEditValue();
+    GEM_VIRTUAL void enterEditValueMode();
+    GEM_VIRTUAL void checkboxToggle();
+    GEM_VIRTUAL void initEditValueCursor();
+    GEM_VIRTUAL void nextEditValueCursorPosition();
+    GEM_VIRTUAL void prevEditValueCursorPosition();
+    GEM_VIRTUAL void drawEditValueCursor();
+    GEM_VIRTUAL void nextEditValueDigit();
+    GEM_VIRTUAL void prevEditValueDigit();
+    GEM_VIRTUAL void drawEditValueDigit(byte code);
+    GEM_VIRTUAL void nextEditValueSelect();
+    GEM_VIRTUAL void prevEditValueSelect();
+    GEM_VIRTUAL void saveEditValue();
+    GEM_VIRTUAL void cancelEditValue();
+    GEM_VIRTUAL void exitEditValue();
     char* trimString(char* str);
 
     /* KEY DETECTION */

--- a/src/GEM_u8g2.h
+++ b/src/GEM_u8g2.h
@@ -41,6 +41,7 @@
 
 #include <U8g2lib.h>
 #include "GEMAppearance.h"
+#include "GEMContext.h"
 #include "GEMPage.h"
 #include "GEMSelect.h"
 #include "constants.h"
@@ -77,19 +78,6 @@ struct FontSize {
 struct FontFamiliesU8g2 {
   const uint8_t *big;    // Big font family (i.e., 6x12)
   const uint8_t *small;  // Small font family (i.e., 4x6)
-};
-
-// Declaration of AppContext type
-struct AppContext {
-  void (*loop)();   // Pointer to loop() function of current context (similar to regular loop() function: if context is defined, executed each regular loop() iteration),
-                    // usually contains code of user-defined action that is run when menu Button is pressed
-  void (*enter)();  // Pointer to enter() function of current context (similar to regular setup() function, called manually, generally once before context's loop() function, optional),
-                    // usually contains some additional set up required by the user-defined action pointed to by context's loop()
-  void (*exit)();   // Pointer to exit() function of current context (executed when user exits currently running context, optional),
-                    // usually contains instructions to do some cleanup after context's loop() and to draw menu on screen again,
-                    // if no user-defined function specified, default action will take place that consists of call to reInit(), drawMenu() and clearContext() methods
-  bool allowExit = true;  // Setting to false will require manually exit the context's loop() from within the loop itself (all necessary key detection should be done in context's loop() accordingly),
-                          // otherwise exit is handled automatically by pressing GEM_KEY_CANCEL key (default is true)
 };
 
 // Forward declaration of necessary classes
@@ -143,7 +131,7 @@ class GEM_u8g2 {
 
     /* CONTEXT OPERATIONS */
 
-    AppContext context;                                       // Currently set context
+    GEMContext context;                                       // Currently set context
     GEM_u8g2& clearContext();                                 // Clear context
 
     /* DRAW OPERATIONS */

--- a/src/config.h
+++ b/src/config.h
@@ -1,24 +1,32 @@
 // AltSerialGraphicLCD support disabled by default (since GEM ver. 1.5).
 // Can be enabled either by defining GEM_ENABLE_GLCD (via compiler flag or define) or manual edition here.
-#define GEM_DISABLE_GLCD
+#define GEM_DISABLE_GLCD                    // Comment this line to enable AltSerialGraphicLCD support
 #if !defined(GEM_DISABLE_GLCD) || defined(GEM_ENABLE_GLCD)
-#include "config/enable-glcd.h"         // Enable AltSerialGraphicLCD version of GEM
+#include "config/enable-glcd.h"             // Enable AltSerialGraphicLCD version of GEM
 #endif
 
 // U8g2 support enabled by default.
 // Can be disabled either by defining GEM_DISABLE_U8G2 (via compiler flag or define) or manual edition here.
 #if !defined(GEM_DISABLE_U8G2)
-#include "config/enable-u8g2.h"         // Enable U8g2 version of GEM
+#include "config/enable-u8g2.h"             // Enable U8g2 version of GEM
 #endif
 
 // Adafruit GFX support enabled by default.
 // Can be disabled either by defining GEM_DISABLE_ADAFRUIT_GFX (via compiler flag or define) or manual edition here.
 #if !defined(GEM_DISABLE_ADAFRUIT_GFX)
-#include "config/enable-adafruit-gfx.h" // Enable Adafruit GFX version of GEM
+#include "config/enable-adafruit-gfx.h"     // Enable Adafruit GFX version of GEM
 #endif
 
 // Support for editable float variables enabled by default.
 // Can be disabled either by defining GEM_DISABLE_FLOAT_EDIT (via compiler flag or define) or manual edition here.
 #if !defined(GEM_DISABLE_FLOAT_EDIT)
-#include "config/support-float-edit.h"  // Support for editable float and double variables (option selects support them regardless of this setting)
+#include "config/support-float-edit.h"      // Support for editable float and double variables (option selects support them regardless of this setting)
+#endif
+
+// Support for Advanced Mode is disabled by default.
+// Advanced Mode provides additional means to modify, customize and extend functionality of GEM.
+// Can be enabled either by defining GEM_ENABLE_ADVANCED_MODE (via compiler flag or define) or manual edition here.
+#define GEM_DISABLE_ADVANCED_MODE           // Comment this line to enable Advanced Mode
+#if !defined(GEM_DISABLE_ADVANCED_MODE) || defined(GEM_ENABLE_ADVANCED_MODE)
+#include "config/enable-advanced-mode.h"    // Enable Advanced Mode
 #endif

--- a/src/config/enable-advanced-mode.h
+++ b/src/config/enable-advanced-mode.h
@@ -1,0 +1,3 @@
+#ifndef GEM_ENABLE_ADVANCED_MODE
+#define GEM_ENABLE_ADVANCED_MODE
+#endif

--- a/src/constants.h
+++ b/src/constants.h
@@ -14,7 +14,7 @@
   For documentation visit:
   https://github.com/Spirik/GEM
   
-  Copyright (c) 2018-2023 Alexander 'Spirik' Spiridonov
+  Copyright (c) 2018-2024 Alexander 'Spirik' Spiridonov
 
   This file is part of GEM library.
 
@@ -59,3 +59,10 @@
                            // (note that char[] array should be big enough to hold select option with the longest value)
 #define GEM_VAL_FLOAT 5    // Associated variable is of type float
 #define GEM_VAL_DOUBLE 6   // Associated variable is of type double
+
+// Macro used internally to mark virtual functions in Advanced Mode
+#ifdef GEM_ENABLE_ADVANCED_MODE
+#define GEM_VIRTUAL virtual
+#else
+#define GEM_VIRTUAL
+#endif


### PR DESCRIPTION
* `AppContext` struct renamed to `GEMContext` (with backwards compatibility with previous name);
* New methods `::setDrawMenuCallback()` and `::removeDrawMenuCallback()` for managing optional callback that is invoked at the end of `::drawMenu()` call;
* Method `::getCurrentAppearance()` made public;
* `private` access specifiers changed to `protected` to make it possible to access internal fields and methods from within user-defined derived (inherited) classes, allowing to extend functionality of GEM;
* Optional "Advanced Mode" introduced, disabled by default but can be enabled via `config.h` or `GEM_ENABLE_ADVANCED_MODE` flag; when enabled some of the internal methods are made `virtual` to make it possible to override those methods in own sketch, allowing further customization and modification of GEM; more features of Advanced Mode may be added in the future;
* Readme updated accordingly.