### PR TITLE
Adafruit GFX version setting sprite size support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1189,6 +1189,11 @@ For more details on customization see corresponding section of the [wiki](https:
   *Returns*: `GEM_adafruit_gfx&`  
   Set text 'magnification' size (as per Adafruit GFX docs) to supplied value. See Adafruit GFX [documentation](http://adafruit.github.io/Adafruit-GFX-Library/html/class_adafruit___g_f_x.html#a39eb4a8a2c9fa4ab7d58ceffd19535d5) for details on internaly called method of the same name. Sprites (i.e. various menu icons) will be scaled maximum up to two times regardless of the value. If not called explicitly, magnification size will be set to 1. Should be called before `init()`.
 
+* *GEM_adafruit_gfx&* **setSpriteSize(** _uint8_t_ size **)**  `Adafruit GFX version only`  
+  *Accepts*: `uint8_t`  
+  *Returns*: `GEM_adafruit_gfx&`  
+  Set sprite scaling factor if it should be different from the text 'magnification' size set through `setTextSize()` method. Sprites (i.e. various menu icons) will be scaled maximum up to two times regardless of the value. If not called explicitly, equals to the text magnification set with `setTextSize()`. Should be called after `setTextSize()` but before `init()`.
+
 * *GEM_adafruit_gfx&* **setFontBig(** _const GFXfont*_ font = GEM_FONT_BIG[, _byte_ width = 6[, _byte_ height = 8[, _byte_ baselineOffset = 8]]] **)**  `Adafruit GFX version`  
   *Accepts*: `const GFXfont*`[, `byte`[, `byte`[, `byte`]]]  
   *Returns*: `GEM_adafruit_gfx&`  

--- a/src/GEM.cpp
+++ b/src/GEM.cpp
@@ -386,7 +386,6 @@ void GEM::printMenuItems() {
         _glcd.drawSprite(_glcd.xdim-8, yDraw, GEM_SPR_ARROW_RIGHT, GLCD_MODE_NORMAL);
         break;
       case GEM_ITEM_BACK:
-        _glcd.setX(11);
         _glcd.drawSprite(5, yDraw, GEM_SPR_ARROW_LEFT, GLCD_MODE_NORMAL);
         break;
       case GEM_ITEM_BUTTON:

--- a/src/GEM.h
+++ b/src/GEM.h
@@ -120,7 +120,7 @@ class GEM {
 
     /* DRAW OPERATIONS */
 
-    GEM_VIRTUAL GEM& drawMenu();                                        // Draw menu on screen, with menu page set earlier in GEM::setMenuPageCurrent()
+    GEM_VIRTUAL GEM& drawMenu();                            // Draw menu on screen, with menu page set earlier in GEM::setMenuPageCurrent()
     GEM& setDrawMenuCallback(void (*drawMenuCallback_)());  // Set callback that will be called at the end of GEM::drawMenu()
     GEM& removeDrawMenuCallback();                          // Remove callback that was called at the end of GEM::drawMenu()
 

--- a/src/GEM_adafruit_gfx.cpp
+++ b/src/GEM_adafruit_gfx.cpp
@@ -280,8 +280,14 @@ GEM_adafruit_gfx& GEM_adafruit_gfx::hideVersion(bool flag) {
 
 GEM_adafruit_gfx& GEM_adafruit_gfx::setTextSize(uint8_t size) {
   _textSize = size > 0 ? size : 1;
+  setSpriteSize(_textSize);
+  return *this;
+}
+
+GEM_adafruit_gfx& GEM_adafruit_gfx::setSpriteSize(uint8_t size) {
+  _spriteSize = size > 0 ? size : 1;
   if (_splash.image == logo[0].image || _splash.image == logo[1].image) {
-    _splash = logo[_textSize > 1 ? 1 : 0];
+    _splash = logo[_spriteSize > 1 ? 1 : 0];
   }
   return *this;
 }
@@ -409,7 +415,7 @@ void GEM_adafruit_gfx::drawTitleBar() {
 }
 
 void GEM_adafruit_gfx::drawSprite(int16_t x, int16_t y, const Splash sprite[], uint16_t color) {
-  byte variant = _textSize > 1 ? 1 : 0;
+  byte variant = _spriteSize > 1 ? 1 : 0;
   _agfx.drawBitmap(x, y, sprite[variant].image, sprite[variant].width, sprite[variant].height, color);
 }
 
@@ -435,7 +441,7 @@ void GEM_adafruit_gfx::printMenuItemFull(const char* str, int offset) {
 
 byte GEM_adafruit_gfx::getMenuItemInsetOffset(bool forSprite) {
   byte menuItemFontSize = getMenuItemFontSize();
-  byte spriteHeight = _textSize > 1 ? sprite_height_scaled : sprite_height;
+  byte spriteHeight = _spriteSize > 1 ? sprite_height_scaled : sprite_height;
   byte menuItemInsetOffset = (getCurrentAppearance()->menuItemHeight - _menuItemFont[menuItemFontSize].height * _textSize) / 2;
   return menuItemInsetOffset + (forSprite ? (_menuItemFont[menuItemFontSize].height * _textSize - spriteHeight) / 2 : -1 * _textSize); // With additional offset for sprites and text for better visual alignment
 }
@@ -482,7 +488,7 @@ void GEM_adafruit_gfx::printMenuItem(GEMItem* menuItemTmp, byte yText, byte yDra
               {
                 GEMSelect* select = menuItemTmp->select;
                 printMenuItemValue(select->getSelectedOptionName(menuItemTmp->linkedVariable));
-                drawSprite(_agfx.width() - 7 * _textSize, yDraw, selectArrows, color);
+                drawSprite(_agfx.width() - 7 * _spriteSize, yDraw, selectArrows, color);
               }
               break;
             #ifdef GEM_SUPPORT_FLOAT_EDIT
@@ -508,14 +514,14 @@ void GEM_adafruit_gfx::printMenuItem(GEMItem* menuItemTmp, byte yText, byte yDra
         } else {
           printMenuItemFull(menuItemTmp->title);
         }
-        drawSprite(_agfx.width() - 8 * _textSize, yDraw, arrowRight, color);
+        drawSprite(_agfx.width() - 8 * _spriteSize, yDraw, arrowRight, color);
         break;
       case GEM_ITEM_BACK:
-        _agfx.setCursor((5 + _menuItemFont[getMenuItemFontSize()].width) * _textSize, yText);
         drawSprite(5 * _textSize, yDraw, arrowLeft, color);
         break;
       case GEM_ITEM_BUTTON:
-        _agfx.setCursor((5 + _menuItemFont[getMenuItemFontSize()].width) * _textSize, yText);
+        byte variant = _spriteSize > 1 ? 1 : 0;
+        _agfx.setCursor((5 * _textSize + arrowBtn[variant].width), yText);
         if (menuItemTmp->readonly) {
           printMenuItemFull(menuItemTmp->title, -1);
           _agfx.print("^");
@@ -745,7 +751,7 @@ void GEM_adafruit_gfx::checkboxToggle() {
     byte menuPointerType = getCurrentAppearance()->menuPointerType;
     uint16_t foreColor = (menuPointerType == GEM_POINTER_DASH) ? _menuForegroundColor : _menuBackgroundColor;
     uint16_t backColor = (menuPointerType == GEM_POINTER_DASH) ? _menuBackgroundColor : _menuForegroundColor;
-    byte variant = _textSize > 1 ? 1 : 0;
+    byte variant = _spriteSize > 1 ? 1 : 0;
     byte menuValuesLeftOffset = getCurrentAppearance()->menuValuesLeftOffset;
     if (!checkboxValue) {
       _agfx.fillRect(menuValuesLeftOffset, topOffset, checkboxChecked[variant].width, checkboxChecked[variant].height, backColor);
@@ -988,7 +994,7 @@ void GEM_adafruit_gfx::drawEditValueSelect() {
   _agfx.setCursor(getCurrentAppearance()->menuValuesLeftOffset, yText);
   
   printMenuItemValue(select->getOptionNameByIndex(_valueSelectNum));
-  drawSprite(_agfx.width() - 7 * _textSize, getCurrentItemTopOffset(true, true), selectArrows, _menuBackgroundColor);
+  drawSprite(_agfx.width() - 7 * _spriteSize, getCurrentItemTopOffset(true, true), selectArrows, _menuBackgroundColor);
   _agfx.setTextColor(_menuForegroundColor);
 }
 

--- a/src/GEM_adafruit_gfx.cpp
+++ b/src/GEM_adafruit_gfx.cpp
@@ -582,9 +582,7 @@ void GEM_adafruit_gfx::drawMenuPointer(bool clear) {
     } else {
       byte yText = pointerPosition + getMenuItemInsetOffset() + _menuItemFont[getMenuItemFontSize()].baselineOffset * _textSize;
       byte yDraw = pointerPosition + getMenuItemInsetOffset(true);
-      byte menuItemsPerScreen = getMenuItemsPerScreen();
-      byte screensCount = (_menuPageCurrent->itemsCount % menuItemsPerScreen == 0) ? _menuPageCurrent->itemsCount / menuItemsPerScreen : _menuPageCurrent->itemsCount / menuItemsPerScreen + 1;
-      _agfx.fillRect(0, pointerPosition - 1, _agfx.width() + (screensCount > 1 ? -2 : 0), menuItemHeight + 1, clear ? _menuBackgroundColor : _menuForegroundColor);
+      _agfx.fillRect(0, pointerPosition - 1, _agfx.width() - 2, menuItemHeight + 1, clear ? _menuBackgroundColor : _menuForegroundColor);
       printMenuItem(menuItemTmp, yText, yDraw, clear ? _menuForegroundColor : _menuBackgroundColor);
       if (menuItemTmp->readonly) {
         for (byte i = 0; i < (menuItemHeight + 2) / 2; i++) {

--- a/src/GEM_adafruit_gfx.cpp
+++ b/src/GEM_adafruit_gfx.cpp
@@ -517,18 +517,18 @@ void GEM_adafruit_gfx::printMenuItem(GEMItem* menuItemTmp, byte yText, byte yDra
         drawSprite(_agfx.width() - 8 * _spriteSize, yDraw, arrowRight, color);
         break;
       case GEM_ITEM_BACK:
-        drawSprite(5 * _textSize, yDraw, arrowLeft, color);
+        drawSprite(5 * _textSize + 2 * (_spriteSize > 1 ? 1 : 0), yDraw, arrowLeft, color);
         break;
       case GEM_ITEM_BUTTON:
         byte variant = _spriteSize > 1 ? 1 : 0;
-        _agfx.setCursor((5 * _textSize + arrowBtn[variant].width), yText);
+        _agfx.setCursor((5 * _textSize + arrowBtn[variant].width + 2 * variant), yText);
         if (menuItemTmp->readonly) {
           printMenuItemFull(menuItemTmp->title, -1);
           _agfx.print("^");
         } else {
           printMenuItemFull(menuItemTmp->title);
         }
-        drawSprite(5 * _textSize, yDraw, arrowBtn, color);
+        drawSprite(5 * _textSize + 2 * variant, yDraw, arrowBtn, color);
         break;
     }
   _agfx.setTextColor(_menuForegroundColor);
@@ -560,27 +560,27 @@ void GEM_adafruit_gfx::drawMenuPointer(bool clear) {
     byte menuItemHeight = getCurrentAppearance()->menuItemHeight;
     if (getCurrentAppearance()->menuPointerType == GEM_POINTER_DASH) {
       byte menuPageScreenTopOffset = getCurrentAppearance()->menuPageScreenTopOffset;
-      _agfx.fillRect(0, menuPageScreenTopOffset, 2 * _textSize, _agfx.height() - menuPageScreenTopOffset, _menuBackgroundColor);
+      _agfx.fillRect(0, menuPageScreenTopOffset, 2 * _spriteSize, _agfx.height() - menuPageScreenTopOffset, _menuBackgroundColor);
       if (menuItemTmp->readonly) {
         for (byte i = 0; i < (menuItemHeight - 1) / 2; i++) {
           _agfx.drawPixel(0, pointerPosition + i * 2, _menuForegroundColor);
           _agfx.drawPixel(1, pointerPosition + i * 2 + 1, _menuForegroundColor);
-          if (_textSize > 1) {
+          if (_spriteSize > 1) {
             _agfx.drawPixel(2, pointerPosition + i * 2, _menuForegroundColor);
             _agfx.drawPixel(3, pointerPosition + i * 2 + 1, _menuForegroundColor);
           }
         }
       } else {
-        _agfx.fillRect(0, pointerPosition, 2 * _textSize, menuItemHeight - 1, _menuForegroundColor);
+        _agfx.fillRect(0, pointerPosition, 2 * _spriteSize, menuItemHeight - 1, _menuForegroundColor);
       }
       if (clear) {
-        byte yText = pointerPosition + getMenuItemInsetOffset() + _menuItemFont[getMenuItemFontSize()].baselineOffset * _textSize;
+        byte yText = pointerPosition + getMenuItemInsetOffset() + _menuItemFont[getMenuItemFontSize()].baselineOffset * _spriteSize;
         byte yDraw = pointerPosition + getMenuItemInsetOffset(true);
-        _agfx.fillRect(5 * _textSize, pointerPosition - 1, _agfx.width() - 2, menuItemHeight + 1, _menuBackgroundColor);
+        _agfx.fillRect(5 * _spriteSize, pointerPosition - 1, _agfx.width() - 2, menuItemHeight + 1, _menuBackgroundColor);
         printMenuItem(menuItemTmp, yText, yDraw, _menuForegroundColor);
       }
     } else {
-      byte yText = pointerPosition + getMenuItemInsetOffset() + _menuItemFont[getMenuItemFontSize()].baselineOffset * _textSize;
+      byte yText = pointerPosition + getMenuItemInsetOffset() + _menuItemFont[getMenuItemFontSize()].baselineOffset * _spriteSize;
       byte yDraw = pointerPosition + getMenuItemInsetOffset(true);
       byte menuItemsPerScreen = getMenuItemsPerScreen();
       byte screensCount = (_menuPageCurrent->itemsCount % menuItemsPerScreen == 0) ? _menuPageCurrent->itemsCount / menuItemsPerScreen : _menuPageCurrent->itemsCount / menuItemsPerScreen + 1;
@@ -590,7 +590,7 @@ void GEM_adafruit_gfx::drawMenuPointer(bool clear) {
         for (byte i = 0; i < (menuItemHeight + 2) / 2; i++) {
           _agfx.drawPixel(0, pointerPosition + i * 2, _menuBackgroundColor);
           _agfx.drawPixel(1, pointerPosition + i * 2 - 1, _menuBackgroundColor);
-          if (_textSize > 1) {
+          if (_spriteSize > 1) {
             _agfx.drawPixel(2, pointerPosition + i * 2, _menuBackgroundColor);
             _agfx.drawPixel(3, pointerPosition + i * 2 - 1, _menuBackgroundColor);
           }

--- a/src/GEM_adafruit_gfx.cpp
+++ b/src/GEM_adafruit_gfx.cpp
@@ -574,13 +574,13 @@ void GEM_adafruit_gfx::drawMenuPointer(bool clear) {
         _agfx.fillRect(0, pointerPosition, 2 * _spriteSize, menuItemHeight - 1, _menuForegroundColor);
       }
       if (clear) {
-        byte yText = pointerPosition + getMenuItemInsetOffset() + _menuItemFont[getMenuItemFontSize()].baselineOffset * _spriteSize;
+        byte yText = pointerPosition + getMenuItemInsetOffset() + _menuItemFont[getMenuItemFontSize()].baselineOffset * _textSize;
         byte yDraw = pointerPosition + getMenuItemInsetOffset(true);
         _agfx.fillRect(5 * _spriteSize, pointerPosition - 1, _agfx.width() - 2, menuItemHeight + 1, _menuBackgroundColor);
         printMenuItem(menuItemTmp, yText, yDraw, _menuForegroundColor);
       }
     } else {
-      byte yText = pointerPosition + getMenuItemInsetOffset() + _menuItemFont[getMenuItemFontSize()].baselineOffset * _spriteSize;
+      byte yText = pointerPosition + getMenuItemInsetOffset() + _menuItemFont[getMenuItemFontSize()].baselineOffset * _textSize;
       byte yDraw = pointerPosition + getMenuItemInsetOffset(true);
       byte menuItemsPerScreen = getMenuItemsPerScreen();
       byte screensCount = (_menuPageCurrent->itemsCount % menuItemsPerScreen == 0) ? _menuPageCurrent->itemsCount / menuItemsPerScreen : _menuPageCurrent->itemsCount / menuItemsPerScreen + 1;

--- a/src/GEM_adafruit_gfx.h
+++ b/src/GEM_adafruit_gfx.h
@@ -140,7 +140,7 @@ class GEM_adafruit_gfx {
 
     /* DRAW OPERATIONS */
 
-    GEM_VIRTUAL GEM_adafruit_gfx& drawMenu();                                       // Draw menu on screen, with menu page set earlier in GEM_adafruit_gfx::setMenuPageCurrent()
+    GEM_VIRTUAL GEM_adafruit_gfx& drawMenu();                           // Draw menu on screen, with menu page set earlier in GEM_adafruit_gfx::setMenuPageCurrent()
     GEM_adafruit_gfx& setDrawMenuCallback(void (*drawMenuCallback_)()); // Set callback that will be called at the end of GEM_adafruit_gfx::drawMenu()
     GEM_adafruit_gfx& removeDrawMenuCallback();                         // Remove callback that was called at the end of GEM_adafruit_gfx::drawMenu()
 

--- a/src/GEM_adafruit_gfx.h
+++ b/src/GEM_adafruit_gfx.h
@@ -122,6 +122,7 @@ class GEM_adafruit_gfx {
     GEM_adafruit_gfx& setSplashDelay(uint16_t value);                   // Set splash screen delay. Default value 1000ms, max value 65535ms. Setting to 0 will disable splash screen. Should be called before GEM_adafruit_gfx::init().
     GEM_adafruit_gfx& hideVersion(bool flag = true);                    // Turn printing of the current GEM library version on splash screen off or back on. Should be called before GEM_adafruit_gfx::init().
     GEM_adafruit_gfx& setTextSize(uint8_t size);                        // Set text 'magnification' size (as per Adafruit GFX docs); sprites will be scaled maximum up to two times regardless of the supplied value (default is 1)
+    GEM_adafruit_gfx& setSpriteSize(uint8_t size);                      // Set sprite scaling factor if it should be different from the 'magnification' size above; sprites will be scaled maximum up to two times regardless of the supplied value (default is 1)
     GEM_adafruit_gfx& setFontBig(const GFXfont* font = GEM_FONT_BIG, uint8_t width = 6, uint8_t height = 8, uint8_t baselineOffset = 8);      // Set big font
     GEM_adafruit_gfx& setFontSmall(const GFXfont* font = GEM_FONT_SMALL, uint8_t width = 4, uint8_t height = 6, uint8_t baselineOffset = 6);  // Set small font
     GEM_adafruit_gfx& setForegroundColor(uint16_t color);               // Set foreground color of the menu (default is 0xFF)
@@ -157,6 +158,7 @@ class GEM_adafruit_gfx {
     FontSizeAGFX _menuItemFont[2] = {{6,8,8},{4,6,6}};
     FontFamiliesAGFX _fontFamilies = {GEM_FONT_BIG, GEM_FONT_SMALL};
     byte _textSize = 1;
+    byte _spriteSize = 1;
     bool _invertKeysDuringEdit = false;
     GEM_VIRTUAL byte getMenuItemTitleLength();
     GEM_VIRTUAL byte getMenuItemValueLength();

--- a/src/GEM_u8g2.cpp
+++ b/src/GEM_u8g2.cpp
@@ -516,7 +516,6 @@ void GEM_u8g2::printMenuItems() {
         _u8g2.drawXBMP(_u8g2.getDisplayWidth() - 8, yDraw, arrowRight_width, arrowRight_height, arrowRight_bits);
         break;
       case GEM_ITEM_BACK:
-        _u8g2.setCursor(11, yText);
         _u8g2.drawXBMP(5, yDraw, arrowLeft_width, arrowLeft_height, arrowLeft_bits);
         break;
       case GEM_ITEM_BUTTON:


### PR DESCRIPTION
* Support for setting sprites 'magnification' size (i.e. scale factor) for Adafruit GFX version via `::setSpriteSize()` regardless of text `magnification` size set via `::setTextSize()` method;
* Readme updated accordingly;
* Cleanup of redundant code.