### PR TITLE
Additional GEMPage and GEMItem public methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1182,7 +1182,7 @@ For more details on customization see corresponding section of the [wiki](https:
   > Keep this in mind if you are planning to use the same object in your own routines.
 
 * *GEM&* **reInit()**  
-  **Returns*: `GEM&`, or `GEM_u8g2&`, or `GEM_adafruit_gfx&`  
+  *Returns*: `GEM&`, or `GEM_u8g2&`, or `GEM_adafruit_gfx&`  
   Set GEM specific settings to their values, set initially in `init()` method. If you were working with AltSerialGraphicLCD, U8g2 or Adafruit GFX graphics in your own user-defined button action, it may be a good idea to call `reInit()` before drawing menu back to screen (generally in custom `context.exit()` routine). See [context](#gemcontext) for more details.
 
 * *GEM_adafruit_gfx&* **setTextSize(** _uint8_t_ size **)**  `Adafruit GFX version only`  
@@ -1361,6 +1361,11 @@ GEMPage menuPage(title[, parentMenuPage]);
   *Accepts*: `byte`  
   *Returns*: `GEMPage&`  
   Set index of currently focused menu item on this page (only visible items are counted).
+
+* *byte* **getItemsCount(** _bool_ total = false **)**  
+  *Accepts*: `bool`  
+  *Returns*: `byte`  
+  Get items count of the menu page, counting hidden ones (if **total** set to `true`, or `GEM_ITEMS_TOTAL`) or only visible (if **total** set to `false`, or `GEM_ITEMS_VISIBLE`).
 
 > **Note:** calls to methods that return a reference to the owning `GEMPage` object can be chained, e.g. `menuPageSettings.addMenuItem(menuItemInterval).addMenuItem(menuItemTempo).setParentMenuPage(menuPageMain);` (since GEM ver. 1.4.6).
 
@@ -1555,6 +1560,66 @@ GEMItem menuItemButton(title, buttonAction[, callbackVal[, readonly]]);
   *Value*: `17`  
   Alias for supported length of the string (character sequence) variable of type `char[GEM_STR_LEN]`. Note that this limits the length of the string that can be used with editable character menu item variable, but option select variable doesn't have this restriction. But you still have to make sure that in the latter case character array should be big enough to hold select option with the longest value to avoid overflows.
 
+* **GEM_ITEM_VAL**  
+  *Type*: macro `#define GEM_ITEM_VAL 0`  
+  *Value*: `0`  
+  Alias for menu item type that represents editable variable.
+
+* **GEM_ITEM_LINK**  
+  *Type*: macro `#define GEM_ITEM_LINK 1`  
+  *Value*: `1`  
+  Alias for menu item type that represents link to another menu page.
+
+* **GEM_ITEM_BACK**  
+  *Type*: macro `#define GEM_ITEM_BACK 2`  
+  *Value*: `2`  
+  Alias for menu item type that represents Back button (that links to parent level menu page).
+
+* **GEM_ITEM_BUTTON**  
+  *Type*: macro `#define GEM_ITEM_BUTTON 3`  
+  *Value*: `3`  
+  Alias for menu item type that represents button.
+
+* **GEM_VAL_INTEGER**  
+  *Type*: macro `#define GEM_VAL_INTEGER 0`  
+  *Value*: `0`  
+  Alias for `int` type of associated with menu item variable.
+
+* **GEM_VAL_BYTE**  
+  *Type*: macro `#define GEM_VAL_BYTE 1`  
+  *Value*: `1`  
+  Alias for `byte` type of associated with menu item variable.
+
+* **GEM_VAL_CHAR**  
+  *Type*: macro `#define GEM_VAL_CHAR 2`  
+  *Value*: `2`  
+  Alias for `char[n]` type of associated with menu item variable.
+
+* **GEM_VAL_BOOL**  
+  *Type*: macro `#define GEM_VAL_BOOL 3`  
+  *Value*: `3`  
+  Alias for `bool` type of associated with menu item variable.
+
+* **GEM_VAL_SELECT**  
+  *Type*: macro `#define GEM_VAL_SELECT 4`  
+  *Value*: `4`  
+  Associated variable is either of type `int`, `byte`, `char[n]`, `float` or `double` with option select used to pick a predefined value from the list.
+
+* **GEM_VAL_FLOAT**  
+  *Type*: macro `#define GEM_VAL_FLOAT 5`  
+  *Value*: `5`  
+  Alias for `float` type of associated with menu item variable.
+
+* **GEM_VAL_DOUBLE**  
+  *Type*: macro `#define GEM_VAL_DOUBLE 6`  
+  *Value*: `6`  
+  Alias for `double` type of associated with menu item variable.
+
+* **GEM_VAL_SPINNER**  
+  *Type*: macro `#define GEM_VAL_SPINNER 7`  
+  *Value*: `7`  
+  Associated variable is either of type `int`, `byte`, `float` or `double` with spinner to increment or decrement value with given step.
+
 #### Methods
 
 * *GEMItem&* **setCallbackVal(** _int_ | _byte_ | _float_ | _double_ | _bool_ | _const char*_ | _void*_ callbackVal **)**  
@@ -1572,6 +1637,16 @@ GEMItem menuItemButton(title, buttonAction[, callbackVal[, readonly]]);
 * *const char** **getTitle()**  
   *Returns*: `const char*`  
   Get title of the menu item.
+
+* *byte* **getLinkedType()**  
+  *Returns*: `byte`  
+  *Return values*: `GEM_VAL_INTEGER`, `GEM_VAL_BYTE`, `GEM_VAL_CHAR`, `GEM_VAL_BOOL`, `GEM_VAL_SELECT`, `GEM_VAL_FLOAT`, `GEM_VAL_DOUBLE`, `GEM_VAL_SPINNER`  
+  Get type of linked variable. Relevant for menu items of type `GEM_ITEM_VAL`. Value is undetermined otherwise.
+
+* *byte* **getType()**  
+  *Returns*: `byte`  
+  *Return values*: `GEM_ITEM_VAL`, `GEM_ITEM_LINK`, `GEM_ITEM_BACK`, `GEM_ITEM_BUTTON`  
+  Get type of menu item.
 
 * *GEMItem&* **setPrecision(** _byte_ prec **)**  
   *Accepts*: `byte`  
@@ -1612,6 +1687,14 @@ GEMItem menuItemButton(title, buttonAction[, callbackVal[, readonly]]);
 * *void** **getLinkedVariablePointer()**  
   *Returns*: `void*`  
   Get pointer to a linked variable (relevant for menu items that represent variable). Note that user is reponsible for casting `void*` pointer to a correct pointer type.
+
+* *GEMPage** **getParentPage()**  
+  *Returns*: `GEMPage*`  
+  Get pointer to menu page that holds this menu item.
+
+* *GEMPage** **getLinkedPage()**  
+  *Returns*: `GEMPage*`  
+  Get pointer to menu page that menu item of type `GEM_ITEM_LINK` or `GEM_ITEM_BACK` links to.
 
 * *GEMItem** **getMenuItemNext(** _bool_ total = false **)**  
   *Accepts*: `bool`  
@@ -2274,7 +2357,7 @@ When support for [Floating-point variables](#floating-point-variables) is enable
 
 Examples
 -----------
-GEM library comes with several annotated examples that will help you get familiar with it. More detailed info on the examples (including schematic and breadboard view where necessary) available in [wiki](https://github.com/Spirik/GEM/wiki).
+GEM library comes with several annotated examples that will help you get familiar with it. More detailed info on the examples (including schematic, breadboard view, simulations and optional custom shield implementation) available in [wiki](https://github.com/Spirik/GEM/wiki).
 
 License
 -----------

--- a/keywords.txt
+++ b/keywords.txt
@@ -64,11 +64,8 @@ setCallbackVal	KEYWORD2
 getCallbackData	KEYWORD2
 setTitle	KEYWORD2
 getTitle	KEYWORD2
-getMenuItem	KEYWORD2
-getCurrentMenuItem	KEYWORD2
-getCurrentMenuItemIndex	KEYWORD2
-setCurrentMenuItemIndex	KEYWORD2
-getMenuItemNext	KEYWORD2
+getLinkedType	KEYWORD2
+getType	KEYWORD2
 setPrecision	KEYWORD2
 setAdjustedASCIIOrder	KEYWORD2
 setReadonly	KEYWORD2
@@ -78,8 +75,16 @@ show	KEYWORD2
 getHidden	KEYWORD2
 remove  KEYWORD2
 getLinkedVariablePointer	KEYWORD2
+getParentPage	KEYWORD2
+getLinkedPage	KEYWORD2
+getMenuItemNext	KEYWORD2
 addMenuItem	KEYWORD2
 setParentMenuPage	KEYWORD2
+getMenuItem	KEYWORD2
+getCurrentMenuItem	KEYWORD2
+getCurrentMenuItemIndex	KEYWORD2
+setCurrentMenuItemIndex	KEYWORD2
+getItemsCount	KEYWORD2
 
 ####################################################
 # Constants (LITERAL1)

--- a/src/GEMItem.cpp
+++ b/src/GEMItem.cpp
@@ -16,7 +16,7 @@
   For documentation visit:
   https://github.com/Spirik/GEM
 
-  Copyright (c) 2018-2024 Alexander 'Spirik' Spiridonov
+  Copyright (c) 2018-2025 Alexander 'Spirik' Spiridonov
 
   This file is part of GEM library.
 
@@ -1767,6 +1767,14 @@ const char* GEMItem::getTitle() {
   return title;
 }
 
+byte GEMItem::getLinkedType() {
+  return linkedType;
+}
+
+byte GEMItem::getType() {
+  return type;
+}
+
 GEMItem& GEMItem::setPrecision(byte prec) {
   precision = prec;
   return *this;
@@ -1825,6 +1833,14 @@ GEMItem& GEMItem::remove() {
 
 void* GEMItem::getLinkedVariablePointer() {
   return linkedVariable;
+}
+
+GEMPage* GEMItem::getParentPage() {
+  return parentPage;
+}
+
+GEMPage* GEMItem::getLinkedPage() {
+  return linkedPage;
 }
 
 GEMItem* GEMItem::getMenuItemNext(bool total) {

--- a/src/GEMItem.h
+++ b/src/GEMItem.h
@@ -16,7 +16,7 @@
   For documentation visit:
   https://github.com/Spirik/GEM
 
-  Copyright (c) 2018-2024 Alexander 'Spirik' Spiridonov
+  Copyright (c) 2018-2025 Alexander 'Spirik' Spiridonov
 
   This file is part of GEM library.
 
@@ -343,6 +343,8 @@ class GEMItem {
     GEMCallbackData getCallbackData();                  // Get GEMCallbackData struct associated with menu item
     GEM_VIRTUAL GEMItem& setTitle(const char* title_);  // Set title of the menu item
     GEM_VIRTUAL const char* getTitle();                 // Get title of the menu item
+    byte getLinkedType();                               // Get type of linked variable (see linkedType field description below for possible values)
+    byte getType();                                     // Get type of menu item (see type field description below for possible values)
     GEMItem& setPrecision(byte prec);                   // Explicitly set precision for float or double variables as required by dtostrf() conversion,
                                                         // i.e. the number of digits after the decimal sign
     GEMItem& setAdjustedASCIIOrder(bool mode = true);   // Turn adjsuted order of characters when editing char[17] variables on (with space character followed by `a` and preceded by `) or off
@@ -356,12 +358,14 @@ class GEMItem {
     bool getHidden();                                   // Get hidden state of the menu item
     GEMItem& remove();                                  // Remove menu item from parent menu page
     GEM_VIRTUAL void* getLinkedVariablePointer();       // Get pointer to a linked variable (relevant for menu items that represent variable)
+    GEM_VIRTUAL GEMPage* getParentPage();               // Get pointer to menu page that holds this menu item
+    GEM_VIRTUAL GEMPage* getLinkedPage();               // Get pointer to menu page that menu link GEM_ITEM_LINK or back button GEM_ITEM_BACK links to
     GEM_VIRTUAL GEMItem* getMenuItemNext(bool total = false); // Get next menu item (including hidden ones if total set to true)
   protected:
     const char* title;
     void* linkedVariable = nullptr;
-    byte linkedType;
-    byte type;
+    byte linkedType;                                    // GEM_VAL_INTEGER, GEM_VAL_BYTE, GEM_VAL_CHAR, GEM_VAL_BOOL, GEM_VAL_SELECT, GEM_VAL_FLOAT, GEM_VAL_DOUBLE, GEM_VAL_SPINNER
+    byte type;                                          // GEM_ITEM_VAL, GEM_ITEM_LINK, GEM_ITEM_BACK, GEM_ITEM_BUTTON
     byte precision = GEM_FLOAT_PREC;
     bool adjustedAsciiOrder = false;
     bool readonly = false;

--- a/src/GEMPage.cpp
+++ b/src/GEMPage.cpp
@@ -16,7 +16,7 @@
   For documentation visit:
   https://github.com/Spirik/GEM
 
-  Copyright (c) 2018-2023 Alexander 'Spirik' Spiridonov
+  Copyright (c) 2018-2025 Alexander 'Spirik' Spiridonov
 
   This file is part of GEM library.
 
@@ -136,6 +136,10 @@ byte GEMPage::getCurrentMenuItemIndex() {
 GEMPage& GEMPage::setCurrentMenuItemIndex(byte index) {
   currentItemNum = index;
   return *this;
+}
+
+byte GEMPage::getItemsCount(bool total) {
+  return total ? itemsCountTotal : itemsCount;
 }
 
 int GEMPage::getMenuItemNum(GEMItem& menuItem, bool total) {

--- a/src/GEMPage.h
+++ b/src/GEMPage.h
@@ -16,7 +16,7 @@
   For documentation visit:
   https://github.com/Spirik/GEM
 
-  Copyright (c) 2018-2023 Alexander 'Spirik' Spiridonov
+  Copyright (c) 2018-2025 Alexander 'Spirik' Spiridonov
 
   This file is part of GEM library.
 
@@ -74,6 +74,7 @@ class GEMPage {
     GEM_VIRTUAL GEMItem* getCurrentMenuItem();                              // Get pointer to current menu item
     GEM_VIRTUAL byte getCurrentMenuItemIndex();                             // Get index of current menu item
     GEMPage& setCurrentMenuItemIndex(byte index);                           // Set index of current menu item
+    GEM_VIRTUAL byte getItemsCount(bool total = false);                     // Get items count of the menu page (counting hidden ones if total set to true)
   protected:
     const char* title;
     byte currentItemNum = 0;                                                // Currently selected (focused) menu item of the page


### PR DESCRIPTION
* `GEMPage::getItemsCount()` method to get items count of the menu page;
* `GEMItem::getType()` and `GEMItem::getLinkedType()` methods to get type of menu item and type of linked variable;
* `GEMItem::getParentPage()` and `GEMItem::getLinkedPage()` methods to get pointer to parent and linked menu pages;
* Readme updated accordingly;
* Note on optional custom shields implementation for easier GEM development and prototyping of projects (available in [wiki](https://github.com/Spirik/GEM/wiki)).