### PR TITLE
AGFX version sprite size bug fix; Loop option for selects/spinners; Optional title for GEMPage constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1099,6 +1099,11 @@ For more details on customization see corresponding section of the [wiki](https:
 
   Alias for the keys (buttons) used to navigate and interact with menu. Submitted to `GEM::registerKeyPress()`, `GEM_u8g2::registerKeyPress()` and `GEM_adafruit_gfx::registerKeyPress()` methods. Indicates that Ok/Apply key is pressed (toggle `bool` menu item, enter edit mode of the associated non-`bool` variable, exit edit mode with saving the variable, execute code associated with button).
 
+* **GEM_LOOP**  
+  *Type*: macro `#define GEM_LOOP true`  
+  *Value*: `true`  
+  Alias for loop modifier of selects and range spinners. Submitted as **loop** setting to `GEMSelect` and `GEMSpinner` constructors.
+
 #### Methods
 
 * *GEM&* **setAppearance(** _GEMAppearance_ appearance **)**  
@@ -1727,7 +1732,7 @@ GEMItem menuItemButton(title, buttonAction[, callbackVal[, readonly]]);
 List of values available for option select. Supplied to `GEMItem` constructor. Object of class `GEMSelect` defines as follows:
 
 ```cpp
-GEMSelect mySelect(length, optionsArray);
+GEMSelect mySelect(length, optionsArray[, loop]);
 ```
 
 * **length**  
@@ -1738,6 +1743,12 @@ GEMSelect mySelect(length, optionsArray);
   *Type*: `void*` (pointer to array of type either `SelectOptionInt`, or `SelectOptionByte`, or `SelectOptionFloat`, or `SelectOptionDouble`, or `SelectOptionChar`)  
   Array of the available options. Type of the array is either `SelectOptionInt`, or `SelectOptionByte`, or `SelectOptionFloat`, or `SelectOptionDouble`, or `SelectOptionChar` depending on the kind of data options are selected from. See the following section for definition of these custom types.
 
+* **loop** [*optional*]  
+  *Type*: `bool`  
+  *Values*: `GEM_LOOP` (alias for `true`), `false`  
+  *Default*: `false`  
+  Sets loop mode for select which defines whether iteration over options should be looped.
+
 Example of use:
 
 ```cpp
@@ -1746,6 +1757,8 @@ Example of use:
 SelectOptionInt optionsArray[] = {{"Opt 1", 10}, {"Opt 2", -12}, {"Opt 3", 13}};
 // 2) Supply array of options to GEMSelect constructor:
 GEMSelect mySelect(sizeof(optionsArray)/sizeof(SelectOptionInt), optionsArray);
+// 3) Optionally enable loop mode:
+GEMSelect mySelect(sizeof(optionsArray)/sizeof(SelectOptionInt), GEM_LOOP);
 ```
 or
 ```cpp
@@ -1753,6 +1766,17 @@ or
 // GEMSelect constructor with anonymous options array (length of array (3) can't be calculated in this case and should be explicitly supplied):
 GEMSelect mySelect(3, (SelectOptionInt[]){{"Opt 1", 10}, {"Opt 2", -12}, {"Opt 3", 13}});
 ```
+
+#### Methods
+
+* *GEMSelect&* **setLoop(** _bool_ mode = true **)**  
+  *Accepts*: `bool`  
+  *Returns*: `GEMSelect&`  
+  Explicitly set (`setLoop(true)`, or `setLoop(GEM_LOOP)`, or `setLoop()`) or unset (`setLoop(false)`) loop mode for select which defines whether iteration over options should be looped.
+
+* *bool* **getLoop()**  
+  *Returns*: `bool`  
+  Get loop state of the select: `true` when looping is enabled, `false` otherwise.
 
 
 ----------
@@ -1849,12 +1873,18 @@ Spinner is similar to option select, but instead of specifying available options
 `GEMSpinner` represents range of values available for incremental spinner. Supplied to `GEMItem` constructor. Object of class `GEMSpinner` defines as follows:
 
 ```cpp
-GEMSpinner mySpinner(boundaries);
+GEMSpinner mySpinner(boundaries[, loop]);
 ```
 
 * **boundaries**  
   *Type*: `GEMSpinnerBoundariesInt`, or `GEMSpinnerBoundariesByte`, or `GEMSpinnerBoundariesFloat`, or `GEMSpinnerBoundariesDouble`  
   Settings of the incremental spinner, such as minimum and maximum boundaries of available values in range, and step with which increment/decrement of value is performed. Type of boundaries object is either `GEMSpinnerBoundariesInt`, or `GEMSpinnerBoundariesByte`, or `GEMSpinnerBoundariesFloat`, or `GEMSpinnerBoundariesDouble` depending on the type of variable the spinner is associated with. See the following section for definition of these custom types.
+
+* **loop** [*optional*]  
+  *Type*: `bool`  
+  *Values*: `GEM_LOOP` (alias for `true`), `false`  
+  *Default*: `false`  
+  Sets loop mode for spinner which defines whether iteration over options should be looped.
 
 Example of use:
 
@@ -1864,6 +1894,8 @@ Example of use:
 GEMSpinnerBoundariesInt mySpinnerBoundaries = { .step = 50, .min = -150, .max = 150 };
 // 2) Supply settings to GEMSpinner constructor:
 GEMSpinner mySpinner(mySpinnerBoundaries);
+// 3) Optionally enable loop mode:
+GEMSpinner mySpinner(mySpinnerBoundaries, GEM_LOOP);
 ```
 
 It is possible to exclude support for spinner menu items to save some space on your chip. For that, locate file [config.h](https://github.com/Spirik/GEM/blob/master/src/config.h) that comes with the library, open it and comment out corresponding inclusion, i.e. change this line:
@@ -1887,6 +1919,17 @@ build_flags =
     ; Disable support for increment/decrement spinner menu items
     -D GEM_DISABLE_SPINNER
 ```
+
+#### Methods
+
+* *GEMSpinner&* **setLoop(** _bool_ mode = true **)**  
+  *Accepts*: `bool`  
+  *Returns*: `GEMSpinner&`  
+  Explicitly set (`setLoop(true)`, or `setLoop(GEM_LOOP)`, or `setLoop()`) or unset (`setLoop(false)`) loop mode for range spinner which defines whether iteration over options should be looped.
+
+* *bool* **getLoop()**  
+  *Returns*: `bool`  
+  Get loop state of the spinner: `true` when looping is enabled, `false` otherwise.
 
 
 ----------

--- a/README.md
+++ b/README.md
@@ -1281,14 +1281,14 @@ For more details on customization see corresponding section of the [wiki](https:
 Menu page holds menu items `GEMItem` and represents menu level. Menu can have multiple menu pages (linked to each other) with multiple menu items each. Object of class `GEMPage` defines as follows:
 
 ```cpp
-GEMPage menuPage(title[, exitAction]);
+GEMPage menuPage([title[, exitAction]]);
 ```
 or
 ```cpp
-GEMPage menuPage(title[, parentMenuPage]);
+GEMPage menuPage([title[, parentMenuPage]]);
 ```
 
-* **title**  
+* **title** [*optional*]  
   *Type*: `const char*`  
   Title of the menu page displayed at top of the screen.
   

--- a/keywords.txt
+++ b/keywords.txt
@@ -85,6 +85,8 @@ getCurrentMenuItem	KEYWORD2
 getCurrentMenuItemIndex	KEYWORD2
 setCurrentMenuItemIndex	KEYWORD2
 getItemsCount	KEYWORD2
+setLoop	KEYWORD2
+getLoop	KEYWORD2
 
 ####################################################
 # Constants (LITERAL1)
@@ -144,6 +146,8 @@ GEM_ITEM_LABEL	LITERAL1
 
 GEM_READONLY	LITERAL1
 GEM_HIDDEN	LITERAL1
+
+GEM_LOOP	LITERAL1
 
 GEM_LAST_POS	LITERAL1
 GEM_ITEMS_TOTAL	LITERAL1

--- a/src/GEM.cpp
+++ b/src/GEM.cpp
@@ -845,13 +845,19 @@ void GEM::nextEditValueSelect() {
   GEMSelect* select = menuItemTmp->select;
   if (_valueSelectNum+1 < select->getLength()) {
     _valueSelectNum++;
+  } else if (select->getLoop()) {
+    _valueSelectNum = 0;
   }
   drawEditValueSelect();
 }
 
 void GEM::prevEditValueSelect() {
+  GEMItem* menuItemTmp = _menuPageCurrent->getCurrentMenuItem();
+  GEMSelect* select = menuItemTmp->select;
   if (_valueSelectNum > 0) {
     _valueSelectNum--;
+  } else if (select->getLoop()) {
+    _valueSelectNum = select->getLength() - 1;
   }
   drawEditValueSelect();
 }
@@ -862,12 +868,21 @@ void GEM::nextEditValueSpinner() {
   GEMSpinner* spinner = menuItemTmp->spinner;
   if (_valueSelectNum+1 < spinner->getLength()) {
     _valueSelectNum++;
+  } else if (spinner->getLoop()) {
+    _valueSelectNum = 0;
   }
   drawEditValueSelect();
 }
 
 void GEM::prevEditValueSpinner() {
-  prevEditValueSelect();
+  GEMItem* menuItemTmp = _menuPageCurrent->getCurrentMenuItem();
+  GEMSpinner* spinner = menuItemTmp->spinner;
+  if (_valueSelectNum > 0) {
+    _valueSelectNum--;
+  } else if (spinner->getLoop()) {
+    _valueSelectNum = spinner->getLength() - 1;
+  }
+  drawEditValueSelect();
 }
 #endif
 

--- a/src/GEMPage.h
+++ b/src/GEMPage.h
@@ -62,7 +62,7 @@ class GEMPage {
       @param 'exitAction_' - pointer to callback function executed when GEM_KEY_CANCEL is pressed while being on top level menu page
       @param 'parentMenuPage_' - reference to parent level menu page (to know where to go back to when Back button is pressed)
     */
-    GEMPage(const char* title_);
+    GEMPage(const char* title_ = "");
     GEMPage(const char* title_, void (*exitAction_)());
     GEMPage(const char* title_, GEMPage& parentMenuPage_);
     GEM_VIRTUAL GEMPage& addMenuItem(GEMItem& menuItem, byte pos = GEM_LAST_POS, bool total = GEM_ITEMS_TOTAL);  // Add menu item to menu page (optionally at specified index out of total or only visible items)

--- a/src/GEMSelect.cpp
+++ b/src/GEMSelect.cpp
@@ -16,7 +16,7 @@
   For documentation visit:
   https://github.com/Spirik/GEM
 
-  Copyright (c) 2018-2023 Alexander 'Spirik' Spiridonov
+  Copyright (c) 2018-2025 Alexander 'Spirik' Spiridonov
 
   This file is part of GEM library.
 
@@ -38,35 +38,49 @@
 #include "GEMSelect.h"
 #include "constants.h"
 
-GEMSelect::GEMSelect(byte length_, SelectOptionInt* options_)
+GEMSelect::GEMSelect(byte length_, SelectOptionInt* options_, bool loop_)
   : _type(GEM_VAL_INTEGER)
   , _length(length_)
   , _options(options_)
+  , _loop(loop_)
 { }
 
-GEMSelect::GEMSelect(byte length_, SelectOptionByte* options_)
+GEMSelect::GEMSelect(byte length_, SelectOptionByte* options_, bool loop_)
   : _type(GEM_VAL_BYTE)
   , _length(length_)
   , _options(options_)
+  , _loop(loop_)
 { }
 
-GEMSelect::GEMSelect(byte length_, SelectOptionChar* options_)
+GEMSelect::GEMSelect(byte length_, SelectOptionChar* options_, bool loop_)
   : _type(GEM_VAL_CHAR)
   , _length(length_)
   , _options(options_)
+  , _loop(loop_)
 { }
 
-GEMSelect::GEMSelect(byte length_, SelectOptionFloat* options_)
+GEMSelect::GEMSelect(byte length_, SelectOptionFloat* options_, bool loop_)
   : _type(GEM_VAL_FLOAT)
   , _length(length_)
   , _options(options_)
+  , _loop(loop_)
 { }
 
-GEMSelect::GEMSelect(byte length_, SelectOptionDouble* options_)
+GEMSelect::GEMSelect(byte length_, SelectOptionDouble* options_, bool loop_)
   : _type(GEM_VAL_DOUBLE)
   , _length(length_)
   , _options(options_)
+  , _loop(loop_)
 { }
+
+GEMSelect& GEMSelect::setLoop(bool mode) {
+  _loop = mode;
+  return *this;
+}
+
+bool GEMSelect::getLoop() {
+  return _loop;
+}
 
 byte GEMSelect::getType() {
   return _type;

--- a/src/GEMSelect.h
+++ b/src/GEMSelect.h
@@ -16,7 +16,7 @@
   For documentation visit:
   https://github.com/Spirik/GEM
 
-  Copyright (c) 2018-2023 Alexander 'Spirik' Spiridonov
+  Copyright (c) 2018-2025 Alexander 'Spirik' Spiridonov
 
   This file is part of GEM library.
 
@@ -43,7 +43,7 @@
 // Declaration of SelectOptionInt type
 struct SelectOptionInt {
   const char* name;    // Text label of the option as displayed in select
-  int val_int;   // Value of the option that is assigned to linked variable upon option selection
+  int val_int;         // Value of the option that is assigned to linked variable upon option selection
 };
 
 // Declaration of SelectOptionByte type
@@ -79,16 +79,21 @@ class GEMSelect {
     /* 
       @param 'length_' - length of the 'options_' array
       @param 'options_' - array of the available options
+      @param 'loop_' (optional) - whether iteration over options should be looped
+      values GEM_LOOP (alias for true)
     */
-    GEMSelect(byte length_, SelectOptionInt* options_);
-    GEMSelect(byte length_, SelectOptionByte* options_);
-    GEMSelect(byte length_, SelectOptionChar* options_);
-    GEMSelect(byte length_, SelectOptionFloat* options_);
-    GEMSelect(byte length_, SelectOptionDouble* options_);
+    GEMSelect(byte length_, SelectOptionInt* options_, bool loop_ = false);
+    GEMSelect(byte length_, SelectOptionByte* options_, bool loop_ = false);
+    GEMSelect(byte length_, SelectOptionChar* options_, bool loop_ = false);
+    GEMSelect(byte length_, SelectOptionFloat* options_, bool loop_ = false);
+    GEMSelect(byte length_, SelectOptionDouble* options_, bool loop_ = false);
+    GEMSelect& setLoop(bool mode = true);  // Explicitly set or unset loop mode
+    bool getLoop();                        // Get current value of loop mode
   protected:
     byte _type;
     byte _length;
     void* _options;
+    bool _loop = false;
     byte getType();
     byte getLength();
     GEM_VIRTUAL int getSelectedOptionNum(void* variable);

--- a/src/GEMSpinner.cpp
+++ b/src/GEMSpinner.cpp
@@ -16,7 +16,7 @@
   For documentation visit:
   https://github.com/Spirik/GEM
 
-  Copyright (c) 2018-2024 Alexander 'Spirik' Spiridonov
+  Copyright (c) 2018-2025 Alexander 'Spirik' Spiridonov
 
   This file is part of GEM library.
 
@@ -38,31 +38,44 @@
 #include "GEMSpinner.h"
 #include "constants.h"
 
-GEMSpinner::GEMSpinner(GEMSpinnerBoundariesByte boundaries_)
+GEMSpinner::GEMSpinner(GEMSpinnerBoundariesByte boundaries_, bool loop_)
   : _boundaries{ { .boundariesByte = { .step = boundaries_.step, .min = boundaries_.min < boundaries_.max ? boundaries_.min : boundaries_.max, .max = boundaries_.max > boundaries_.min ? boundaries_.max : boundaries_.min } } }
   , _type(GEM_VAL_BYTE)
   , _length(abs((boundaries_.max - boundaries_.min) / boundaries_.step) + 1)
+  , _loop(loop_)
 { }
 
-GEMSpinner::GEMSpinner(GEMSpinnerBoundariesInt boundaries_)
+GEMSpinner::GEMSpinner(GEMSpinnerBoundariesInt boundaries_, bool loop_)
   : _boundaries{ { .boundariesInt = { .step = abs(boundaries_.step), .min = boundaries_.min < boundaries_.max ? boundaries_.min : boundaries_.max, .max = boundaries_.max > boundaries_.min ? boundaries_.max : boundaries_.min } } }
   , _type(GEM_VAL_INTEGER)
   , _length(abs((boundaries_.max - boundaries_.min) / boundaries_.step) + 1)
+  , _loop(loop_)
 { }
 
 #ifdef GEM_SUPPORT_FLOAT_EDIT
-GEMSpinner::GEMSpinner(GEMSpinnerBoundariesFloat boundaries_)
+GEMSpinner::GEMSpinner(GEMSpinnerBoundariesFloat boundaries_, bool loop_)
   : _boundaries{ { .boundariesFloat = { .step = abs(boundaries_.step), .min = boundaries_.min < boundaries_.max ? boundaries_.min : boundaries_.max, .max = boundaries_.max > boundaries_.min ? boundaries_.max : boundaries_.min } } }
   , _type(GEM_VAL_FLOAT)
   , _length(abs((boundaries_.max - boundaries_.min) / boundaries_.step) + 1)
+  , _loop(loop_)
 { }
 
-GEMSpinner::GEMSpinner(GEMSpinnerBoundariesDouble boundaries_)
+GEMSpinner::GEMSpinner(GEMSpinnerBoundariesDouble boundaries_, bool loop_)
   : _boundaries{ { .boundariesDouble = { .step = abs(boundaries_.step), .min = boundaries_.min < boundaries_.max ? boundaries_.min : boundaries_.max, .max = boundaries_.max > boundaries_.min ? boundaries_.max : boundaries_.min } } }
   , _type(GEM_VAL_DOUBLE)
   , _length(abs((boundaries_.max - boundaries_.min) / boundaries_.step) + 1)
+  , _loop(loop_)
 { }
 #endif
+
+GEMSpinner& GEMSpinner::setLoop(bool mode) {
+  _loop = mode;
+  return *this;
+}
+
+bool GEMSpinner::getLoop() {
+  return _loop;
+}
 
 byte GEMSpinner::getType() {
   return _type;

--- a/src/GEMSpinner.h
+++ b/src/GEMSpinner.h
@@ -16,7 +16,7 @@
   For documentation visit:
   https://github.com/Spirik/GEM
 
-  Copyright (c) 2018-2024 Alexander 'Spirik' Spiridonov
+  Copyright (c) 2018-2025 Alexander 'Spirik' Spiridonov
 
   This file is part of GEM library.
 
@@ -102,17 +102,22 @@ class GEMSpinner {
   public:
     /* 
       @param 'boundaries_' - boundaries of the spinner of corresponding type
+      @param 'loop_' (optional) - whether iteration over options should be looped
+      values GEM_LOOP (alias for true)
     */
-    GEMSpinner(GEMSpinnerBoundariesByte boundaries_);
-    GEMSpinner(GEMSpinnerBoundariesInt boundaries_);
+    GEMSpinner(GEMSpinnerBoundariesByte boundaries_, bool loop_ = false);
+    GEMSpinner(GEMSpinnerBoundariesInt boundaries_, bool loop_ = false);
     #ifdef GEM_SUPPORT_FLOAT_EDIT
-    GEMSpinner(GEMSpinnerBoundariesFloat boundaries_);
-    GEMSpinner(GEMSpinnerBoundariesDouble boundaries_);
+    GEMSpinner(GEMSpinnerBoundariesFloat boundaries_, bool loop_ = false);
+    GEMSpinner(GEMSpinnerBoundariesDouble boundaries_, bool loop_ = false);
     #endif
+    GEMSpinner& setLoop(bool mode = true);  // Explicitly set or unset loop mode
+    bool getLoop();                         // Get current value of loop mode
   protected:
     GEMSpinnerBoundaries _boundaries;
     byte _type;
     int _length;
+    bool _loop = false;
     byte getType();
     int getLength();
     GEM_VIRTUAL int getSelectedOptionNum(void* variable);

--- a/src/GEM_adafruit_gfx.cpp
+++ b/src/GEM_adafruit_gfx.cpp
@@ -1018,13 +1018,19 @@ void GEM_adafruit_gfx::nextEditValueSelect() {
   GEMSelect* select = menuItemTmp->select;
   if (_valueSelectNum+1 < select->getLength()) {
     _valueSelectNum++;
+  } else if (select->getLoop()) {
+    _valueSelectNum = 0;
   }
   drawEditValueSelect();
 }
 
 void GEM_adafruit_gfx::prevEditValueSelect() {
+  GEMItem* menuItemTmp = _menuPageCurrent->getCurrentMenuItem();
+  GEMSelect* select = menuItemTmp->select;
   if (_valueSelectNum > 0) {
     _valueSelectNum--;
+  } else if (select->getLoop()) {
+    _valueSelectNum = select->getLength() - 1;
   }
   drawEditValueSelect();
 }
@@ -1035,12 +1041,21 @@ void GEM_adafruit_gfx::nextEditValueSpinner() {
   GEMSpinner* spinner = menuItemTmp->spinner;
   if (_valueSelectNum+1 < spinner->getLength()) {
     _valueSelectNum++;
+  } else if (spinner->getLoop()) {
+    _valueSelectNum = 0;
   }
   drawEditValueSelect();
 }
 
 void GEM_adafruit_gfx::prevEditValueSpinner() {
-  prevEditValueSelect();
+  GEMItem* menuItemTmp = _menuPageCurrent->getCurrentMenuItem();
+  GEMSpinner* spinner = menuItemTmp->spinner;
+  if (_valueSelectNum > 0) {
+    _valueSelectNum--;
+  } else if (spinner->getLoop()) {
+    _valueSelectNum = spinner->getLength() - 1;
+  }
+  drawEditValueSelect();
 }
 #endif
 

--- a/src/GEM_adafruit_gfx.cpp
+++ b/src/GEM_adafruit_gfx.cpp
@@ -285,7 +285,7 @@ GEM_adafruit_gfx& GEM_adafruit_gfx::setTextSize(uint8_t size) {
 }
 
 GEM_adafruit_gfx& GEM_adafruit_gfx::setSpriteSize(uint8_t size) {
-  _spriteSize = size > 0 ? size : 1;
+  _spriteSize = size > 1 ? 2 : 1;
   if (_splash.image == logo[0].image || _splash.image == logo[1].image) {
     _splash = logo[_spriteSize > 1 ? 1 : 0];
   }
@@ -415,7 +415,7 @@ void GEM_adafruit_gfx::drawTitleBar() {
 }
 
 void GEM_adafruit_gfx::drawSprite(int16_t x, int16_t y, const Splash sprite[], uint16_t color) {
-  byte variant = _spriteSize > 1 ? 1 : 0;
+  byte variant = _spriteSize - 1;
   _agfx.drawBitmap(x, y, sprite[variant].image, sprite[variant].width, sprite[variant].height, color);
 }
 
@@ -448,6 +448,10 @@ byte GEM_adafruit_gfx::getMenuItemInsetOffset(bool forSprite) {
 
 byte GEM_adafruit_gfx::getCurrentItemTopOffset(bool withInsetOffset, bool forSprite) {
   return (_menuPageCurrent->currentItemNum % getMenuItemsPerScreen()) * getCurrentAppearance()->menuItemHeight + getCurrentAppearance()->menuPageScreenTopOffset + (withInsetOffset ? getMenuItemInsetOffset(forSprite) : 0);
+}
+
+byte GEM_adafruit_gfx::calculateSpriteOverlap(const Splash sprite[]) {
+  return ((sprite[_spriteSize - 1].width - 3 * _textSize) / _menuItemFont[getMenuItemFontSize()].width * _textSize);
 }
 
 void GEM_adafruit_gfx::printMenuItem(GEMItem* menuItemTmp, byte yText, byte yDraw, uint16_t color) {
@@ -488,7 +492,7 @@ void GEM_adafruit_gfx::printMenuItem(GEMItem* menuItemTmp, byte yText, byte yDra
           case GEM_VAL_SELECT:
             {
               GEMSelect* select = menuItemTmp->select;
-              printMenuItemValue(select->getSelectedOptionName(menuItemTmp->linkedVariable));
+              printMenuItemValue(select->getSelectedOptionName(menuItemTmp->linkedVariable), -1 * calculateSpriteOverlap(selectArrows));
               drawSprite(_agfx.width() - 7 * _spriteSize, yDraw, selectArrows, color);
             }
             break;
@@ -512,7 +516,7 @@ void GEM_adafruit_gfx::printMenuItem(GEMItem* menuItemTmp, byte yText, byte yDra
                   break;
                 #endif
               }
-              printMenuItemValue(valueStringTmp);
+              printMenuItemValue(valueStringTmp, -1 * calculateSpriteOverlap(selectArrows));
               drawSprite(_agfx.width() - 7 * _spriteSize, yDraw, selectArrows, color);
             }
             break;
@@ -538,7 +542,7 @@ void GEM_adafruit_gfx::printMenuItem(GEMItem* menuItemTmp, byte yText, byte yDra
         printMenuItemFull(menuItemTmp->title, -1);
         _agfx.print("^");
       } else {
-        printMenuItemFull(menuItemTmp->title);
+        printMenuItemFull(menuItemTmp->title, -1 * calculateSpriteOverlap(arrowRight));
       }
       drawSprite(_agfx.width() - 8 * _spriteSize, yDraw, arrowRight, color);
       break;
@@ -1053,7 +1057,7 @@ void GEM_adafruit_gfx::drawEditValueSelect() {
     case GEM_VAL_SELECT:
       {
         GEMSelect* select = menuItemTmp->select;
-        printMenuItemValue(select->getOptionNameByIndex(_valueSelectNum));
+        printMenuItemValue(select->getOptionNameByIndex(_valueSelectNum), -1 * calculateSpriteOverlap(selectArrows));
       }
       break;
     #ifdef GEM_SUPPORT_SPINNER
@@ -1078,7 +1082,7 @@ void GEM_adafruit_gfx::drawEditValueSelect() {
             break;
           #endif
         }
-        printMenuItemValue(valueStringTmp);
+        printMenuItemValue(valueStringTmp, -1 * calculateSpriteOverlap(selectArrows));
       }
       break;
     #endif

--- a/src/GEM_adafruit_gfx.h
+++ b/src/GEM_adafruit_gfx.h
@@ -187,6 +187,7 @@ class GEM_adafruit_gfx {
     GEM_VIRTUAL void printMenuItemFull(const char* str, int offset = 0);
     GEM_VIRTUAL byte getMenuItemInsetOffset(bool forSprite = false);
     GEM_VIRTUAL byte getCurrentItemTopOffset(bool withInsetOffset = true, bool forSprite = false);
+    GEM_VIRTUAL byte calculateSpriteOverlap(const Splash sprite[]);
     GEM_VIRTUAL void printMenuItem(GEMItem* menuItemTmp, byte yText, byte yDraw, uint16_t color);
     GEM_VIRTUAL void printMenuItems();
     GEM_VIRTUAL void drawMenuPointer(bool clear = false);

--- a/src/GEM_u8g2.cpp
+++ b/src/GEM_u8g2.cpp
@@ -976,13 +976,19 @@ void GEM_u8g2::nextEditValueSelect() {
   GEMSelect* select = menuItemTmp->select;
   if (_valueSelectNum+1 < select->getLength()) {
     _valueSelectNum++;
+  } else if (select->getLoop()) {
+    _valueSelectNum = 0;
   }
   drawMenu();
 }
 
 void GEM_u8g2::prevEditValueSelect() {
+  GEMItem* menuItemTmp = _menuPageCurrent->getCurrentMenuItem();
+  GEMSelect* select = menuItemTmp->select;
   if (_valueSelectNum > 0) {
     _valueSelectNum--;
+  } else if (select->getLoop()) {
+    _valueSelectNum = select->getLength() - 1;
   }
   drawMenu();
 }
@@ -993,12 +999,21 @@ void GEM_u8g2::nextEditValueSpinner() {
   GEMSpinner* spinner = menuItemTmp->spinner;
   if (_valueSelectNum+1 < spinner->getLength()) {
     _valueSelectNum++;
+  } else if (spinner->getLoop()) {
+    _valueSelectNum = 0;
   }
   drawMenu();
 }
 
 void GEM_u8g2::prevEditValueSpinner() {
-  prevEditValueSelect();
+  GEMItem* menuItemTmp = _menuPageCurrent->getCurrentMenuItem();
+  GEMSpinner* spinner = menuItemTmp->spinner;
+  if (_valueSelectNum > 0) {
+    _valueSelectNum--;
+  } else if (spinner->getLoop()) {
+    _valueSelectNum = spinner->getLength() - 1;
+  }
+  drawMenu();
 }
 #endif
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -61,6 +61,9 @@
 #define GEM_VAL_DOUBLE 6   // Associated variable is of type double
 #define GEM_VAL_SPINNER 7  // Associated variable is either of type int, byte, float or double with spinner to increment or decrement value with given step
 
+// Macro constant (alias) for loop modifier of selects (GEMSelect) and range spinners (GEMSpinner)
+#define GEM_LOOP true
+
 // Macro used internally to mark virtual functions in Advanced Mode
 #ifdef GEM_ENABLE_ADVANCED_MODE
 #define GEM_VIRTUAL virtual


### PR DESCRIPTION
* Bugfix for select/spinner arrows sprite overlapping option label when non-supported value of `_spriteSize` (> 2) is set through `GEM_adafruit_gfx::setSpriteSize()` (as mentioned in #119);
* `title` argument made optional in GEMPage constructor: now it is possible to call `GEMPage menuPage` to create menu page with empty title (see #118);
* Optional `loop` setting for selects (GEMSelect) and spinners (GEMSpinner) added to allow endless loop through the options (see #124);
* Readme updated accordingly.